### PR TITLE
Add groups tests

### DIFF
--- a/api/api/V1/Group.ts
+++ b/api/api/V1/Group.ts
@@ -100,8 +100,23 @@ export default function (app: Application, baseUrl: string) {
    * @apiParam {JSON} where [Sequelize where conditions](http://docs.sequelizejs.com/manual/tutorial/querying.html#where) for query.
    *
    * @apiUse V1ResponseSuccess
-   * @apiSuccess {Groups[]} groups Array of groups
-   *
+   * @apiSuccess {ApiGroup[]} groups Array of ApiGroup[]
+   * @apiSuccess {Number} groups.id Identifier of the group
+   * @apiSuccess {String} groups.groupname Name of the group
+   * @apiSuccess {ApiGroupUserRelation[]} groups.Users List of all associated group users and their relationship to the group
+   * @apiSuccess {ApiGroupUser[]} groups.GroupUsers List of users associated with the group
+   * @apiSuccess {ApiDeviceIdAndName[]} groups.Devices List of devices associated with the group
+   * @apiSuccessExample {JSON} ApiGroup:
+   * {
+   *   id: number;
+   *   groupname: string;
+   *   Users: ApiGroupUserRelation[];
+   *   Devices: ApiDeviceIdAndName[];
+   *   GroupUsers: ApiGroupUser[];
+   * }
+   * @apiUse ApiGroupUserRelation
+   * @apiUse ApiDeviceIdAndName
+   * @apiUse ApiGroupUser
    * @apiUse V1ResponseError
    */
   app.get(
@@ -129,12 +144,30 @@ export default function (app: Application, baseUrl: string) {
    * @api {get} /api/v1/groups/{groupNameOrId} Get a group by name or id
    * @apiName GetGroup
    * @apiGroup Group
+   * @apiDescription A group member or an admin member with globalRead permissions can view details of a group.
+   *
+   * @apiParam {Number|String} groupIdOrName group id or group name
    *
    * @apiUse V1UserAuthorizationHeader
    *
    * @apiUse V1ResponseSuccess
-   * @apiSuccess {Group} groups Array of groups (but should only contain one item)
-   *
+   * @apiSuccess {ApiGroup[]} groups Array of ApiGroup[] (but should only contain one item)
+   * @apiSuccess {Number} groups.id Identifier of the group
+   * @apiSuccess {String} groups.groupname Name of the group
+   * @apiSuccess {ApiGroupUserRelation[]} groups.Users Relationship between current user and the group
+   * @apiSuccess {ApiGroupUser[]} groups.GroupUsers List of users associated with the group
+   * @apiSuccess {ApiDeviceIdAndName[]} groups.Devices List of devices associated with the group
+   * @apiSuccessExample {JSON} ApiGroup:
+   * {
+   *   id: number;
+   *   groupname: string;
+   *   Users: ApiGroupUserRelation[];
+   *   Devices: ApiDeviceIdAndName[];
+   *   GroupUsers: ApiGroupUser[];
+   * }
+   * @apiUse ApiGroupUserRelation
+   * @apiUse ApiDeviceIdAndName
+   * @apiUse ApiGroupUser
    * @apiUse V1ResponseError
    */
   app.get(
@@ -167,9 +200,16 @@ export default function (app: Application, baseUrl: string) {
    *
    * @apiUse V1UserAuthorizationHeader
    *
-   * @apiParam {Number|String} group name or group id
+   * @apiParam {Number|String} groupIdOrName group id or group name
    *
    * @apiUse V1ResponseSuccess
+   * @apiSuccess {ApiGroupsDevice[]} devices List of devices associated with the group
+   * @apiSuccessExample {JSON} ApiGroupsDevice:
+   * {
+   *   id: number;
+   *   deviceName: string;
+   * }
+
    * @apiUse V1ResponseError
    */
   app.get(
@@ -241,10 +281,19 @@ export default function (app: Application, baseUrl: string) {
    *
    * @apiUse V1UserAuthorizationHeader
    *
-   * @apiParam {Number|String} group name or group id
+   * @apiParam {Number|String} groupIdOrName group id or group name
    *
    * @apiUse V1ResponseSuccess
+   * @apiSuccess {ApiGroupUser[]} users Array of ApiGroupUser listing users assigned to this group
    * @apiUse V1ResponseError
+   * @apiSuccessExample {JSON} ApiGroupUser:
+   * {
+   *  "id":456,
+   *  "userName":"user name",
+   *  "isGroupAdmin":true
+   * }
+
+   *
    */
   app.get(
     `${apiUrl}/:groupIdOrName/users`,
@@ -273,14 +322,14 @@ export default function (app: Application, baseUrl: string) {
    * @api {post} /api/v1/groups/users Add a user to a group.
    * @apiName AddUserToGroup
    * @apiGroup Group
-   * @apiDescription This call can add a user to a group. Has to be authenticated
+   * @apiDescription This call can add a user to a group. It must to be authenticated
    * by an admin from the group or a user with global write permission. It can also be used to update the
    * admin status of a user for the group by setting admin to true or false.
    *
    * @apiUse V1UserAuthorizationHeader
    *
-   * @apiParam {Number} group name of the group.
-   * @apiParam {Number} username name of the user to add to the grouop.
+   * @apiParam {String} group name of the group.
+   * @apiParam {String} username name of the user to add to the group.
    * @apiParam {Boolean} admin If the user should be an admin for the group.
    *
    * @apiUse V1ResponseSuccess
@@ -316,8 +365,8 @@ export default function (app: Application, baseUrl: string) {
    *
    * @apiUse V1UserAuthorizationHeader
    *
-   * @apiParam {Number} group name of the group.
-   * @apiParam {Number} username username of user to remove from the grouop.
+   * @apiParam {String} group name of the group.
+   * @apiParam {String} username username of user to remove from the group.
    *
    * @apiUse V1ResponseSuccess
    * @apiUse V1ResponseError
@@ -350,8 +399,9 @@ export default function (app: Application, baseUrl: string) {
    *
    * @apiUse V1UserAuthorizationHeader
    *
-   * @apiParam {Number|String} group name or group id
-   * @apiParam {JSON} Json array of {name: string, lat: number, lng: number}
+   * @apiParam {Number|String} groupNameOrId group name or group id
+   * @apiParam {Station[]} stations Json array of {name: string, lat: number, lng: number}
+   * @apiParam {Date} fromDate Start date/time for the new station
    *
    * @apiUse V1ResponseSuccess
    * @apiUse V1ResponseError

--- a/api/api/V1/Group.ts
+++ b/api/api/V1/Group.ts
@@ -459,7 +459,7 @@ export default function (app: Application, baseUrl: string) {
    * @apiSuccess {ApiStationDetail[]} stations Array of ApiStationDetail[] showing details of stations in group
    * @apiSuccess {Number} stations.id Id of station
    * @apiSuccess {Number} stations.GroupId Id of the group to which the station belongs
-   * @apiSuccess {String} stations.createdAt Timestamp station was created 
+   * @apiSuccess {String} stations.createdAt Timestamp station was created
    * (Note: this is the database record creation date, not the user-supplied fromDate)
    * @apiSuccess {String} stations.retiredAt Timestamp station was retired
    * @apiSuccess {String} stations.updatedAt Timestamp station was last updated
@@ -478,7 +478,7 @@ export default function (app: Application, baseUrl: string) {
    *   updatedAt: "2021-08-27T21:04:35.855Z"
    * }
    * @apiSuccessExample {JSON} ApiLocation:
-   * Note: these coordinates are currently reversed (Issue 73). 
+   * Note: these coordinates are currently reversed (Issue 73).
    * {
    *   type: 'Point',
    *   coordinates: [ -45.0, 172.9 ]

--- a/api/api/V1/Group.ts
+++ b/api/api/V1/Group.ts
@@ -400,10 +400,20 @@ export default function (app: Application, baseUrl: string) {
    * @apiUse V1UserAuthorizationHeader
    *
    * @apiParam {Number|String} groupNameOrId group name or group id
-   * @apiParam {Station[]} stations Json array of {name: string, lat: number, lng: number}
-   * @apiParam {Date} fromDate Start date/time for the new station
+   * @apiParam {Station[]} stations Json array of ApiStation[]
+   * @apiParam {Date} fromDate Start date/time for the new station as ISO timestamp (e.g. '2021-05-19T02:45:01.236Z')
+   * @apiParamExample {json} ApiStation:
+   * {
+   *   name: "Station Name:,
+   *   lat: -45.1,
+   *   lng: 172.0
+   * }
    *
    * @apiUse V1ResponseSuccess
+   * @apiSuccess {Number[]} stationIdsAddedOrUpdated Array of Identifiers of stations added or updated.
+   * @apiSuccess {JSON} updatedRecordingsPerStation Hash of {stationId:recordingId, ...} showing recordings updated
+   * by the request.
+   * @apiSuccess {string} warnings Warnings showing data validation rule breaches for the applied stations.
    * @apiUse V1ResponseError
    */
   app.post(
@@ -443,9 +453,36 @@ export default function (app: Application, baseUrl: string) {
    *
    * @apiUse V1UserAuthorizationHeader
    *
-   * @apiParam {Number|String} group name or group id
+   * @apiParam {Number|String} groupIdOrName Group name or group id
    *
    * @apiUse V1ResponseSuccess
+   * @apiSuccess {ApiStationDetail[]} stations Array of ApiStationDetail[] showing details of stations in group
+   * @apiSuccess {Number} stations.id Id of station
+   * @apiSuccess {Number} stations.GroupId Id of the group to which the station belongs
+   * @apiSuccess {String} stations.createdAt Timestamp station was created 
+   * (Note: this is the database record creation date, not the user-supplied fromDate)
+   * @apiSuccess {String} stations.retiredAt Timestamp station was retired
+   * @apiSuccess {String} stations.updatedAt Timestamp station was last updated
+   * @apiSuccess {Number} stations.lastUpdatedById Id of the user account last used to update the station
+   * @apiSuccess {ApiLocation} stations.location JSON detailing location of the station
+   * @apiSuccess {String} stations.name Name of the station
+   * @apiSuccessExample {JSON} ApiStationDetail:
+   * {
+   *   GroupId: 1338,
+   *   createdAt: "2021-08-27T21:04:35.851Z",
+   *   id: 415,
+   *   lastUpdatedById: 2069,
+   *   location:  ApiLocation,
+   *   name: "station1",
+   *   retiredAt: null,
+   *   updatedAt: "2021-08-27T21:04:35.855Z"
+   * }
+   * @apiSuccessExample {JSON} ApiLocation:
+   * Note: these coordinates are currently reversed (Issue 73). 
+   * {
+   *   type: 'Point',
+   *   coordinates: [ -45.0, 172.9 ]
+   * }
    * @apiUse V1ResponseError
    */
   app.get(

--- a/api/api/V1/apidoc.js
+++ b/api/api/V1/apidoc.js
@@ -136,3 +136,35 @@
  *    "dateTimes": ["2017-11-13T00:47:51.160Z"]
  *  }
  */
+/**
+ * @apiDefine ApiGroupUserRelation
+ * @apiSuccessExample {json} ApiGroupUserRelation
+ *  {
+ *    id: 123,
+ *    username: "name of user making query",
+ *    GroupUsers: {
+ *      admin: true,
+ *      createdAt: "2017-11-13T00:47:51.160Z",
+ *      updatedAt: "2017-11-13T00:47:51.160Z",
+ *      GroupId: 234,
+ *      UserId: 123
+ *    }
+ *  }
+ */
+/**
+ * @apiDefine ApiGroupUser
+ * @apiSuccessExample {json} ApiGroupUser
+ *  {
+ *    username: "name-of-a-group-member",
+ *    id: 1234,
+ *    isAdmin: false
+ *  }
+ */
+/**
+ * @apiDefine ApiDeviceIdAndName
+ * @apiSuccessExample {json} ApiDeviceIdAndName
+ *  {
+ *    id: 123456,
+ *    devicename: "test-camera"
+ *  }
+ */

--- a/integration-tests/cypress/browse/users/group.ts
+++ b/integration-tests/cypress/browse/users/group.ts
@@ -12,7 +12,7 @@ describe("Group Admin Pages", () => {
   const trashButton = ".trash-button";
 
   before(() => {
-    cy.apiCreateUser(Anna);
+    cy.apiUserAdd(Anna);
     cy.visit("/");
   });
 
@@ -85,15 +85,15 @@ describe("Group Admin Pages", () => {
     const Admin = true;
 
     ensureFriendsForeverGroupExists();
-    cy.apiCreateUser(Friend);
-    cy.apiCreateUser(GoodFriend);
+    cy.apiUserAdd(Friend);
+    cy.apiUserAdd(GoodFriend);
 
     cy.addUserToGroup(GoodFriend, FriendsForever, Admin);
     cy.addUserToGroup(Friend, FriendsForever).then(() => {
       cy.get(usersTable).contains(Friend);
     });
 
-    cy.apiGroupUserCheckAccess(Friend, FriendsForever);
+    cy.testGroupUserCheckAccess(Friend, FriendsForever);
 
     // check admin status reflected in table
     cy.get(getUserRow(GoodFriend)).get(adminCol).should("contain", "Yes");
@@ -107,7 +107,7 @@ describe("Group Admin Pages", () => {
   it("Can see camera added to group", () => {
     const Camera = "camera";
     ensureFriendsForeverGroupExists();
-    cy.apiCreateDevice(Camera, FriendsForever);
+    cy.apiDeviceAdd(Camera, FriendsForever);
     cy.checkDeviceInGroup(Camera, FriendsForever);
   });
 

--- a/integration-tests/cypress/browse/users/group.ts
+++ b/integration-tests/cypress/browse/users/group.ts
@@ -93,7 +93,7 @@ describe("Group Admin Pages", () => {
       cy.get(usersTable).contains(Friend);
     });
 
-    cy.apiCheckUserCanSeeGroup(Friend, FriendsForever);
+    cy.apiGroupUserCheckAccess(Friend, FriendsForever);
 
     // check admin status reflected in table
     cy.get(getUserRow(GoodFriend)).get(adminCol).should("contain", "Yes");

--- a/integration-tests/cypress/browse/users/new_user_and_camera.ts
+++ b/integration-tests/cypress/browse/users/new_user_and_camera.ts
@@ -11,7 +11,7 @@ context("Users can see footage from their cameras", () => {
     cy.createGroup(group);
 
     // create a camera in the group
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
 
     // check that user can see camera
     cy.checkDeviceInGroup(camera, group);
@@ -32,6 +32,6 @@ context("Users can see footage from their cameras", () => {
     cy.uploadRecording(camera, {});
     // for video to be uploaded
     cy.wait(3 * 1000);
-    cy.apiCheckDeviceHasRecordings(username, camera, 1);
+    cy.testCheckDeviceHasRecordings(username, camera, 1);
   });
 });

--- a/integration-tests/cypress/browse/users/new_user_and_camera.ts
+++ b/integration-tests/cypress/browse/users/new_user_and_camera.ts
@@ -29,7 +29,7 @@ context("Users can see footage from their cameras", () => {
 
   it("A camera can trigger and upload a new recording", () => {
     cy.apiSignInAs(username);
-    cy.uploadRecording(camera, {});
+    cy.apiRecordingAdd(camera, {});
     // for video to be uploaded
     cy.wait(3 * 1000);
     cy.testCheckDeviceHasRecordings(username, camera, 1);

--- a/integration-tests/cypress/commands/api/device.d.ts
+++ b/integration-tests/cypress/commands/api/device.d.ts
@@ -13,7 +13,7 @@ declare namespace Cypress {
      * create a device in the given group
      * optionally check for non-200 statusCode
      */
-    apiCreateDevice(
+    apiDeviceAdd(
       deviceName: string,
       groupName: string,
       saltId?: number,
@@ -44,7 +44,7 @@ declare namespace Cypress {
      * pass optional params (params) to API call
      * optionally check for a non-200 status code
      */
-    apiCheckDevices(
+    apiDevicesCheck(
       userName: string,
       expectedDevice: ApiDevicesDevice[],
       params?: any,
@@ -52,9 +52,9 @@ declare namespace Cypress {
     ): any;
 
     /**
-     * Same as apiCheckDevices but check the expected items are on the list, rather than the only things on the list
+     * Same as apiDevicesCheck but check the expected items are on the list, rather than the only things on the list
      */
-    apiCheckDevicesContains(
+    apiDevicesCheckContains(
       userName: string,
       expectedDevices: ApiDevicesDevice[],
       params?: string,
@@ -67,7 +67,7 @@ declare namespace Cypress {
      * compare with expected device details (JSON equivalent to that retunred by API)
      * optionally check for a non-200 status code
      */
-    apiCheckDeviceInGroup(
+    apiDeviceInGroupCheck(
       userName: string,
       deviceName: string,
       groupName: string,
@@ -83,7 +83,7 @@ declare namespace Cypress {
      * optionally use operator to specify whether to AND or OR the groups and devices conditions supplier (default=OR)
      * optionally check for a non-200 status code
      */
-    apiCheckDevicesQuery(
+    apiDeviceQueryCheck(
       userName: string,
       devicesArray: TestDeviceAndGroup[],
       groupsArray: string[],
@@ -98,7 +98,7 @@ declare namespace Cypress {
      * takes devicename and looks up the device Id to pass tot he API.  Hence devicename must be unique within test environment
      * optionally check for a non-200 status code
      */
-    apiCheckDevicesUsers(
+    apiDeviceUsersCheck(
       userName: string,
       deviceName: string,
       expectedUsers: ApiDeviceUsersUser[],
@@ -111,7 +111,7 @@ declare namespace Cypress {
      * takes devicename and looks up the device Id to pass tot he API.  Hence devicename must be unique within test environment
      * optionally check for a non-200 status code
      */
-    apiAddUserToDevice(
+    apiDeviceUserAdd(
       deviceAdminUser: string,
       userName: string,
       deviceName: string,
@@ -124,7 +124,7 @@ declare namespace Cypress {
      * takes devicename and looks up the device Id to pass tot he API.  Hence devicename must be unique within test environment
      * optionally check for a non-200 status code
      */
-    apiRemoveUserFromDevice(
+    apiDeviceUserRemove(
       deviceAdminUser: string,
       userName: string,
       deviceName: string,

--- a/integration-tests/cypress/commands/api/device.ts
+++ b/integration-tests/cypress/commands/api/device.ts
@@ -20,7 +20,7 @@ import {
 } from "../types";
 
 Cypress.Commands.add(
-  "apiCreateDevice",
+  "apiDeviceAdd",
   (
     deviceName: string,
     groupName: string,
@@ -150,7 +150,7 @@ function createDevice(
 }
 
 Cypress.Commands.add(
-  "apiCheckDevices",
+  "apiDevicesCheck",
   (
     userName: string,
     expectedDevices: ApiDevicesDevice[],
@@ -224,7 +224,7 @@ function checkDeviceMatchesExpected(
 }
 
 Cypress.Commands.add(
-  "apiCheckDevicesContains",
+  "apiDevicesCheckContains",
   (
     userName: string,
     expectedDevices: ApiDevicesDevice[],
@@ -273,7 +273,7 @@ Cypress.Commands.add(
 );
 
 Cypress.Commands.add(
-  "apiCheckDeviceInGroup",
+  "apiDeviceInGroupCheck",
   (
     userName: string,
     deviceName: string,
@@ -350,7 +350,7 @@ Cypress.Commands.add(
 );
 
 Cypress.Commands.add(
-  "apiCheckDevicesQuery",
+  "apiDeviceQueryCheck",
   (
     userName: string,
     devicesArray: TestDeviceAndGroup[],
@@ -426,7 +426,7 @@ Cypress.Commands.add(
 );
 
 Cypress.Commands.add(
-  "apiCheckDevicesUsers",
+  "apiDeviceUsersCheck",
   (
     userName: string,
     deviceName: string,
@@ -472,7 +472,7 @@ Cypress.Commands.add(
 );
 
 Cypress.Commands.add(
-  "apiAddUserToDevice",
+  "apiDeviceUserAdd",
   (
     deviceAdminUser: string,
     userName: string,
@@ -502,7 +502,7 @@ Cypress.Commands.add(
 );
 
 Cypress.Commands.add(
-  "apiRemoveUserFromDevice",
+  "apiDeviceUserRemove",
   (
     deviceAdminUser: string,
     userName: string,

--- a/integration-tests/cypress/commands/api/events.d.ts
+++ b/integration-tests/cypress/commands/api/events.d.ts
@@ -94,7 +94,7 @@ declare namespace Cypress {
      * Legacy test  function to check the this device is reported as stopped or not
      *
      */
-    apiPowerEventsCheckAgainstExpected(
+    testPowerEventsCheckAgainstExpected(
       userName: string,
       deviceName: string,
       expectedEvent: TestComparablePowerEvent,
@@ -106,7 +106,7 @@ declare namespace Cypress {
      * if supplied then Nth event will be checked where N is taken from eventNumber
      * eventName will be rendered unique _per test_
      */
-    apiEventsCheckAgainstExpected(
+    testEventsCheckAgainstExpected(
       userName: string,
       deviceName: string,
       eventName: string,

--- a/integration-tests/cypress/commands/api/events.ts
+++ b/integration-tests/cypress/commands/api/events.ts
@@ -331,7 +331,7 @@ Cypress.Commands.add(
 );
 
 Cypress.Commands.add(
-  "apiPowerEventsCheckAgainstExpected",
+  "testPowerEventsCheckAgainstExpected",
   (
     userName: string,
     deviceName: string,
@@ -351,7 +351,7 @@ Cypress.Commands.add(
 );
 
 Cypress.Commands.add(
-  "apiEventsCheckAgainstExpected",
+  "testEventsCheckAgainstExpected",
   (
     userName: string,
     deviceName: string,

--- a/integration-tests/cypress/commands/api/group.d.ts
+++ b/integration-tests/cypress/commands/api/group.d.ts
@@ -46,7 +46,7 @@ declare namespace Cypress {
      * Optionally: disable sorting of arrays before comparing (additionalChecks["doNotSort"]=true)
      * Optionally: use the raw groupName provided (additionalChecks["useRawGroupName"]=true)
      */
-    apiGroupsDevicesCheck(userName: string, groupNameOrId: any,  expectedDevices: ApiGroupsDevice[], excludeCheckOn?: string[], statusCode?: number, additionalChecks?: any):any;
+    apiGroupDevicesCheck(userName: string, groupNameOrId: any,  expectedDevices: ApiGroupsDevice[], excludeCheckOn?: string[], statusCode?: number, additionalChecks?: any):any;
 
     /**
      * Add user to group
@@ -83,7 +83,7 @@ declare namespace Cypress {
      * By default userName and groupName are converted into unique (for this test run) names.
      * Optionally: use the raw groupName provided (additionalChecks["useRawGroupName"]=true)
      */
-   apiGroupsStationsUpdate( userName: string, groupIdOrName: string, stations: ApiStationData[], updateFrom?: string, statusCode?: number, additionalChecks?: any):any;
+   apiGroupStationsUpdate( userName: string, groupIdOrName: string, stations: ApiStationData[], updateFrom?: string, statusCode?: number, additionalChecks?: any):any;
 
 
     /**
@@ -105,7 +105,7 @@ declare namespace Cypress {
      * Verify that user can see a group
      * Optionally verify they can't see the group (set testForSuccess=false)
      */
-    apiGroupUserCheckAccess(
+    testGroupUserCheckAccess(
       username: string,
       groupname: string,
       testForSuccess?: boolean

--- a/integration-tests/cypress/commands/api/group.d.ts
+++ b/integration-tests/cypress/commands/api/group.d.ts
@@ -2,49 +2,113 @@
 /// <reference types="cypress" />
 
 declare namespace Cypress {
+  type ApiGroupsUserReturned = import("../types").ApiGroupsUserReturned;
+  type ApiGroupReturned = import("../types").ApiGroupReturned;
+  type ApiDeviceIdAndName = import("../types").ApiDeviceIdAndName;
+  type ApiGroupsDevice = import("../types").ApiGroupsDevice;
+  type ApiStationData = import("../types").ApiStationData;
+  type ApiStationDataReturned = import("../types").ApiStationDataReturned;
+
   interface Chainable {
     /**
-     * create a group for the given user (who has already been referenced in the test
+     * create a group for the given user (who has already been referenced in the test)
+     * Optionally check for fail response (statusCode!=200))
+     * By default userName and groupName are converted into unique (for this test run) names.
+     * Optionally: use the raw groupName provided (additionalChecks["useRawGroupName"]=true)
      */
-    apiCreateGroup(userName: string, groupName: string, log?: boolean): any;
+    apiGroupAdd(userName: string, groupName: string, log?: boolean, statusCode?: number, additionalChecks?: any): any;
 
     /**
-     * create a group for the given user (who has already been referenced in the test
+     * Call api/v1/groups/<groupnameorid> and check that returned values match expectedGroups
+     * Optionally check for fail response (statusCode!=200)
+     * By default userName and groupName are converted into unique (for this test run) names.
+     * Optionally: use the raw groupName provided (additionalChecks["useRawGroupName"]=true)
+     * By default groups and expectedGroups are sorted on groupName before comparison and 
+     * devices by devicename, Users by username, GroupUsers by userId
+     * Optionally: disable sorting of arrays before comparing (additionalChecks["doNotSort"]=true)
      */
-    apiCreateGroup(userName: string, groupName: string, log?: boolean): any;
+    apiGroupCheck(userName: string, groupNameOrId: string,  expectedGroups: ApiGroupReturned[], excludeCheckOn?: string[], statusCode?: number, additionalChecks?:any):any;
+
+
+    /**
+     * Call api/v1/groups and check that returned values match expectedGroups
+     * Optionally check for fail response (statusCode!=200)
+     * By default groups and expectedGroups are sorted on groupName before comparison and 
+     * devices by devicename, Users by username, GroupUsers by userId
+     * Optionally: disable sorting of arrays before comparing (additionalChecks["doNotSort"]=true)
+     */
+    apiGroupsCheck(userName: string, where: any, expectedGroups: ApiGroupReturned[], excludeCheckOn?: string[], statusCode?: number, additionalChecks?: any):any;
+
+    /**
+     * Call api/v1/groups/<groupnameorid>/devices and check that returned values match expectedGroups
+     * Optionally check for fail response (statusCode!=200)
+     * By default devices and expectedDevices are sorted on devicename before comparison
+     * Optionally: disable sorting of arrays before comparing (additionalChecks["doNotSort"]=true)
+     * Optionally: use the raw groupName provided (additionalChecks["useRawGroupName"]=true)
+     */
+    apiGroupsDevicesCheck(userName: string, groupNameOrId: any,  expectedDevices: ApiGroupsDevice[], excludeCheckOn?: string[], statusCode?: number, additionalChecks?: any):any;
+
+    /**
+     * Add user to group
+     * Optionally check for fail response (statusCode!=200)
+     * By default userName and groupName are converted into unique (for this test run) names.
+     * Optionally: use the raw groupName provided (additionalChecks["useRawGroupName"]=true)
+     */
+    apiGroupUserAdd( groupAdminUser: string, userName: string, groupName: string, admin?: boolean, log?: boolean, statusCode?: number,  additionalChecks?: any): any;
+
+
+    /**
+     * Call api/v1/groups/<groupname>/users and check that returned values match expectedUsers
+     * Optionally check for fail response (statusCode!=200)
+     * By default userName and groupName are converted into unique (for this test run) names.
+     * Optionally: use the raw groupName provided (additionalChecks["useRawGroupName"]=true)
+     * By default users and expectedUsers are sorted on userName before comparison
+     * Optionally: disable sorting of arrays before comparing (additionalChecks["doNotSort"]=true)
+     */
+    apiGroupUsersCheck(userName: string, groupName: string, expectedUsers: ApiGroupsUserReturned[], excludeCheckOn?: string[], statusCode?: number, additionalChecks?: any):any;
+
+
+    /**
+     * Remove user from group
+     * Optionally check for fail response (statusCode!=200)
+     * By default userName and groupName are converted into unique (for this test run) names.
+     * Optionally: use the raw groupName provided (additionalChecks["useRawGroupName"]=true)
+     */
+    apiGroupUserRemove( groupAdminUser: string, userName: string, groupName: string, statusCode?: number, additionalChecks?: any): any;
+
+
+    /**
+     * POST to api/v1/groups/<groupidorname>/stations to add, update or retire stations from the group
+     * Optionally check for fail response (statusCode!=200)
+     * By default userName and groupName are converted into unique (for this test run) names.
+     * Optionally: use the raw groupName provided (additionalChecks["useRawGroupName"]=true)
+     */
+   apiGroupsStationsUpdate( userName: string, groupIdOrName: string, stations: ApiStationData[], updateFrom?: string, statusCode?: number, additionalChecks?: any):any;
+
+
+    /**
+     * Call api/v1/groups/<groupidorname>/stations and check that returned values match expectedStations
+     * Optionally check for fail response (statusCode!=200)
+     * By default userName and groupName are converted into unique (for this test run) names.
+     * Optionally: use the raw groupName provided (additionalChecks["useRawGroupName"]=true)
+     * By default stations and expectedStations are sorted on userName before comparison
+     * Optionally: disable sorting of arrays before comparing (additionalChecks["doNotSort"]=true)
+     */
+   apiGroupsStationsCheck(userName: string, groupIdOrName: any, expectedStations: ApiStationDataReturned[], excludeCheckOn?: string[], statusCode?: number, additionalChecks?: any):any;
+
+    /*******************************************************************************************************
+     * Following are legacy test functions from old tests. The above standard-format API wrappers should be used in
+     * preference to these functions.  These may be deleted in the future 
+     *****************************************************************************************************/
 
     /**
      * Verify that user can see a group
      * Optionally verify they can't see the group (set testForSuccess=false)
      */
-    apiCheckUserCanSeeGroup(
+    apiGroupUserCheckAccess(
       username: string,
       groupname: string,
       testForSuccess?: boolean
-    ): any;
-
-    /**
-     * Add user to group
-     * Optionally check for fail response (statusCode!=200)
-     */
-    apiAddUserToGroup(
-      groupAdminUser: string,
-      userName: string,
-      groupName: string,
-      admin?: boolean,
-      log?: boolean,
-      statusCode?: number
-    ): any;
-
-    /**
-     * Remove user from group
-     * Optionally check for fail response (statusCode!=200)
-     */
-    apiRemoveUserFromGroup(
-      groupAdminUser: string,
-      userName: string,
-      groupName: string,
-      statusCode?: number
     ): any;
   }
 }

--- a/integration-tests/cypress/commands/api/group.d.ts
+++ b/integration-tests/cypress/commands/api/group.d.ts
@@ -16,28 +16,47 @@ declare namespace Cypress {
      * By default userName and groupName are converted into unique (for this test run) names.
      * Optionally: use the raw groupName provided (additionalChecks["useRawGroupName"]=true)
      */
-    apiGroupAdd(userName: string, groupName: string, log?: boolean, statusCode?: number, additionalChecks?: any): any;
+    apiGroupAdd(
+      userName: string,
+      groupName: string,
+      log?: boolean,
+      statusCode?: number,
+      additionalChecks?: any
+    ): any;
 
     /**
      * Call api/v1/groups/<groupnameorid> and check that returned values match expectedGroups
      * Optionally check for fail response (statusCode!=200)
      * By default userName and groupName are converted into unique (for this test run) names.
      * Optionally: use the raw groupName provided (additionalChecks["useRawGroupName"]=true)
-     * By default groups and expectedGroups are sorted on groupName before comparison and 
+     * By default groups and expectedGroups are sorted on groupName before comparison and
      * devices by devicename, Users by username, GroupUsers by userId
      * Optionally: disable sorting of arrays before comparing (additionalChecks["doNotSort"]=true)
      */
-    apiGroupCheck(userName: string, groupNameOrId: string,  expectedGroups: ApiGroupReturned[], excludeCheckOn?: string[], statusCode?: number, additionalChecks?:any):any;
-
+    apiGroupCheck(
+      userName: string,
+      groupNameOrId: string,
+      expectedGroups: ApiGroupReturned[],
+      excludeCheckOn?: string[],
+      statusCode?: number,
+      additionalChecks?: any
+    ): any;
 
     /**
      * Call api/v1/groups and check that returned values match expectedGroups
      * Optionally check for fail response (statusCode!=200)
-     * By default groups and expectedGroups are sorted on groupName before comparison and 
+     * By default groups and expectedGroups are sorted on groupName before comparison and
      * devices by devicename, Users by username, GroupUsers by userId
      * Optionally: disable sorting of arrays before comparing (additionalChecks["doNotSort"]=true)
      */
-    apiGroupsCheck(userName: string, where: any, expectedGroups: ApiGroupReturned[], excludeCheckOn?: string[], statusCode?: number, additionalChecks?: any):any;
+    apiGroupsCheck(
+      userName: string,
+      where: any,
+      expectedGroups: ApiGroupReturned[],
+      excludeCheckOn?: string[],
+      statusCode?: number,
+      additionalChecks?: any
+    ): any;
 
     /**
      * Call api/v1/groups/<groupnameorid>/devices and check that returned values match expectedGroups
@@ -46,7 +65,14 @@ declare namespace Cypress {
      * Optionally: disable sorting of arrays before comparing (additionalChecks["doNotSort"]=true)
      * Optionally: use the raw groupName provided (additionalChecks["useRawGroupName"]=true)
      */
-    apiGroupDevicesCheck(userName: string, groupNameOrId: any,  expectedDevices: ApiGroupsDevice[], excludeCheckOn?: string[], statusCode?: number, additionalChecks?: any):any;
+    apiGroupDevicesCheck(
+      userName: string,
+      groupNameOrId: any,
+      expectedDevices: ApiGroupsDevice[],
+      excludeCheckOn?: string[],
+      statusCode?: number,
+      additionalChecks?: any
+    ): any;
 
     /**
      * Add user to group
@@ -54,8 +80,15 @@ declare namespace Cypress {
      * By default userName and groupName are converted into unique (for this test run) names.
      * Optionally: use the raw groupName provided (additionalChecks["useRawGroupName"]=true)
      */
-    apiGroupUserAdd( groupAdminUser: string, userName: string, groupName: string, admin?: boolean, log?: boolean, statusCode?: number,  additionalChecks?: any): any;
-
+    apiGroupUserAdd(
+      groupAdminUser: string,
+      userName: string,
+      groupName: string,
+      admin?: boolean,
+      log?: boolean,
+      statusCode?: number,
+      additionalChecks?: any
+    ): any;
 
     /**
      * Call api/v1/groups/<groupname>/users and check that returned values match expectedUsers
@@ -65,8 +98,14 @@ declare namespace Cypress {
      * By default users and expectedUsers are sorted on userName before comparison
      * Optionally: disable sorting of arrays before comparing (additionalChecks["doNotSort"]=true)
      */
-    apiGroupUsersCheck(userName: string, groupName: string, expectedUsers: ApiGroupsUserReturned[], excludeCheckOn?: string[], statusCode?: number, additionalChecks?: any):any;
-
+    apiGroupUsersCheck(
+      userName: string,
+      groupName: string,
+      expectedUsers: ApiGroupsUserReturned[],
+      excludeCheckOn?: string[],
+      statusCode?: number,
+      additionalChecks?: any
+    ): any;
 
     /**
      * Remove user from group
@@ -74,8 +113,13 @@ declare namespace Cypress {
      * By default userName and groupName are converted into unique (for this test run) names.
      * Optionally: use the raw groupName provided (additionalChecks["useRawGroupName"]=true)
      */
-    apiGroupUserRemove( groupAdminUser: string, userName: string, groupName: string, statusCode?: number, additionalChecks?: any): any;
-
+    apiGroupUserRemove(
+      groupAdminUser: string,
+      userName: string,
+      groupName: string,
+      statusCode?: number,
+      additionalChecks?: any
+    ): any;
 
     /**
      * POST to api/v1/groups/<groupidorname>/stations to add, update or retire stations from the group
@@ -83,8 +127,14 @@ declare namespace Cypress {
      * By default userName and groupName are converted into unique (for this test run) names.
      * Optionally: use the raw groupName provided (additionalChecks["useRawGroupName"]=true)
      */
-   apiGroupStationsUpdate( userName: string, groupIdOrName: string, stations: ApiStationData[], updateFrom?: string, statusCode?: number, additionalChecks?: any):any;
-
+    apiGroupStationsUpdate(
+      userName: string,
+      groupIdOrName: string,
+      stations: ApiStationData[],
+      updateFrom?: string,
+      statusCode?: number,
+      additionalChecks?: any
+    ): any;
 
     /**
      * Call api/v1/groups/<groupidorname>/stations and check that returned values match expectedStations
@@ -94,11 +144,18 @@ declare namespace Cypress {
      * By default stations and expectedStations are sorted on userName before comparison
      * Optionally: disable sorting of arrays before comparing (additionalChecks["doNotSort"]=true)
      */
-   apiGroupsStationsCheck(userName: string, groupIdOrName: any, expectedStations: ApiStationDataReturned[], excludeCheckOn?: string[], statusCode?: number, additionalChecks?: any):any;
+    apiGroupsStationsCheck(
+      userName: string,
+      groupIdOrName: any,
+      expectedStations: ApiStationDataReturned[],
+      excludeCheckOn?: string[],
+      statusCode?: number,
+      additionalChecks?: any
+    ): any;
 
     /*******************************************************************************************************
      * Following are legacy test functions from old tests. The above standard-format API wrappers should be used in
-     * preference to these functions.  These may be deleted in the future 
+     * preference to these functions.  These may be deleted in the future
      *****************************************************************************************************/
 
     /**

--- a/integration-tests/cypress/commands/api/group.ts
+++ b/integration-tests/cypress/commands/api/group.ts
@@ -391,8 +391,8 @@ Cypress.Commands.add(
           sortDevices = response.body.devices;
           sortExpectedDevices = expectedDevices;
         } else {
-          sortDevices = sortArrayOn(response.body.devices, "devicename");
-          sortExpectedDevices = sortArrayOn(expectedDevices, "devicename");
+          sortDevices = sortArrayOn(response.body.devices, "deviceName");
+          sortExpectedDevices = sortArrayOn(expectedDevices, "deviceName");
         }
 
         checkTreeStructuresAreEqualExcept(

--- a/integration-tests/cypress/commands/api/group.ts
+++ b/integration-tests/cypress/commands/api/group.ts
@@ -2,31 +2,33 @@
 /// <reference types="cypress" />
 
 import { getTestName } from "../names";
+import { logTestDescription, prettyLog } from "../descriptions";
+
 import {
   getCreds,
-  makeAuthorizedRequest,
   makeAuthorizedRequestWithStatus,
   saveIdOnly,
   v1ApiPath,
+  sortArrayOn,
+  sortArrayOnTwoKeys,
+  checkTreeStructuresAreEqualExcept
 } from "../server";
-import { logTestDescription } from "../descriptions";
 
-Cypress.Commands.add(
-  "apiAddUserToGroup",
-  (
-    groupAdminUser: string,
-    userName: string,
-    group: string,
-    admin = false,
-    log = true,
-    statusCode: number = 200
-  ) => {
+import { ApiGroupsUserReturned, ApiGroupReturned, ApiGroupsDevice, ApiStationData, ApiStationDataReturned } from "../types";
+
+Cypress.Commands.add( "apiGroupUserAdd", ( groupAdminUser: string, userName: string, groupName: string, admin = false, log = true, statusCode: number = 200, additionalChecks: any = {}) => {
+    let fullGroupName:string;
+    if(additionalChecks["useRawGroupName"]===true) {
+      fullGroupName = groupName;
+    } else {
+      fullGroupName = getTestName(groupName);
+    }
     const adminStr = admin ? " as admin " : "";
     logTestDescription(
-      `${groupAdminUser} Adding user '${userName}' ${adminStr} to group '${group}' ${
+      `${groupAdminUser} Adding user '${userName}' ${adminStr} to group '${groupName}' ${
         admin ? "as admin" : ""
       }`,
-      { user: userName, group, isAdmin: admin },
+      { user: userName, groupName, isAdmin: admin },
       log
     );
 
@@ -35,7 +37,7 @@ Cypress.Commands.add(
         method: "POST",
         url: v1ApiPath("groups/users"),
         body: {
-          group: getTestName(group),
+          group: fullGroupName,
           admin: admin.toString(),
           username: getTestName(userName),
         },
@@ -47,16 +49,17 @@ Cypress.Commands.add(
 );
 
 Cypress.Commands.add(
-  "apiRemoveUserFromGroup",
-  (
-    groupAdminUser: string,
-    userName: string,
-    group: string,
-    statusCode: number = 200
-  ) => {
+  "apiGroupUserRemove", ( groupAdminUser: string, userName: string, groupName: string, statusCode: number = 200, additionalChecks: any = {}) => {
+    let fullGroupName:string;
+    if(additionalChecks["useRawGroupName"]===true) {
+      fullGroupName = groupName;
+    } else {
+      fullGroupName = getTestName(groupName);
+    }
+
     logTestDescription(
-      `${groupAdminUser} Removing user '${userName}' from group '${group}' `,
-      { user: userName, group },
+      `${groupAdminUser} Removing user '${userName}' from group '${groupName}' `,
+      { user: userName, groupName },
       true
     );
 
@@ -65,7 +68,7 @@ Cypress.Commands.add(
         method: "DELETE",
         url: v1ApiPath("groups/users"),
         body: {
-          group: getTestName(group),
+          group: fullGroupName,
           username: getTestName(userName),
         },
       },
@@ -76,15 +79,336 @@ Cypress.Commands.add(
 );
 
 Cypress.Commands.add(
-  "apiCheckUserCanSeeGroup",
-  (username: string, groupname: string, testForSuccess: boolean = true) => {
-    const user = getCreds(username);
-    const fullGroupname = getTestName(groupname);
+  "apiGroupUsersCheck",
+  (userName: string, groupName: string,  expectedUsers: ApiGroupsUserReturned[], excludeCheckOn: string[] = [], statusCode: number = 200, additionalChecks: any = {}) => {
+    let fullGroupName:string;
+    let sortUsers:ApiGroupsUserReturned[];
+    let sortExpectedUsers:ApiGroupsUserReturned[];
+
+    if(additionalChecks["useRawGroupName"]===true) {
+      fullGroupName = groupName;
+    } else {
+      fullGroupName = getTestName(groupName);
+    }
+
+    const fullUrl = v1ApiPath(`groups/${fullGroupName}/users`);
+
+    logTestDescription(
+      `${userName} Check users in group '${groupName}' `,
+      { user: userName, groupName },
+      true
+    );
+
+    //send the request
+    makeAuthorizedRequestWithStatus(
+      { url: fullUrl },
+      userName,
+      statusCode
+    ).then((response) => {
+        if (statusCode === 200) {
+          //sort expected and actual events into same order (means dateTime is mandatory in expectedEvents)
+          if (additionalChecks["doNotSort"] === true) {
+            sortUsers = response.body.users;
+            sortExpectedUsers = expectedUsers;
+          } else {
+            sortUsers = sortArrayOn(response.body.users, "userName");
+            sortExpectedUsers = sortArrayOn(expectedUsers, "userName");
+          }
+          checkTreeStructuresAreEqualExcept(
+            sortExpectedUsers,
+            sortUsers,
+            excludeCheckOn
+          );
+        }
+    });
+  }
+);
+
+Cypress.Commands.add(
+  "apiGroupAdd",
+  (userName: string, groupName: string, log = true, statusCode:number = 200, additionalChecks: any = {}) => {
+      let fullGroupName:string;
+
+      if(additionalChecks["useRawGroupName"]===true) {
+        fullGroupName = groupName;
+      } else {
+        fullGroupName = getTestName(groupName);
+      }
+
+    logTestDescription(
+      `Create group '${groupName}' for user '${userName}'`,
+      { user: userName, group: groupName },
+      log
+    );
+
+    makeAuthorizedRequestWithStatus(
+      {
+        method: "POST",
+        url: v1ApiPath("groups"),
+        body: { groupname: fullGroupName },
+      },
+      userName,
+      statusCode
+    ).then((response) => {
+        if (statusCode === 200) {
+          saveIdOnly(groupName, response.body.groupId);
+	}
+    });
+  }
+);
+
+Cypress.Commands.add(
+  "apiGroupCheck",
+  (userName: string, groupNameOrId: string,  expectedGroups: ApiGroupReturned[], excludeCheckOn: string[] = [], statusCode: number = 200, additionalChecks: any = {}) => {
+    let sortGroups:ApiGroupReturned[];
+    let sortExpectedGroups:ApiGroupReturned[];
+    let fullGroupName:string;
+
+    //Make group name unique unless we're asked not to
+    if(additionalChecks["useRawGroupName"]===true) {
+      fullGroupName = groupNameOrId;
+    } else {
+      fullGroupName = getTestName(groupNameOrId);
+    }
+  
+    const fullUrl = v1ApiPath(`groups/${fullGroupName}`);
+  
+    logTestDescription(
+      `${userName} Check group '${groupNameOrId}' `,
+      { user: userName, groupNameOrId },
+      true
+    );
+  
+    //send the request
+    makeAuthorizedRequestWithStatus(
+      { url: fullUrl },
+      userName,
+      statusCode
+    ).then((response) => {
+        if (statusCode === 200) {
+          //sort expected and actual events into same order (means groupName, devicename, username, userId is mandatory in expectedGroup)
+          if (additionalChecks["doNotSort"] === true) {
+            sortGroups = sortArrayOn(response.body.groups, "groupName");
+            sortExpectedGroups = sortArrayOn(expectedGroups, "groupName");
+            for (let count=0; count < sortGroups.length; count++) {
+              sortGroups[count].Devices = sortArrayOn(sortGroups[count].Devices, "devicename");
+              sortGroups[count].Users = sortArrayOn(sortGroups[count].Users, "username");
+              sortGroups[count].GroupUsers = sortArrayOn(sortGroups[count].GroupUsers, "userId");
+            };
+            for (let count=0; count < sortExpectedGroups.length; count++) {
+              sortExpectedGroups[count].Devices = sortArrayOn(sortExpectedGroups[count].Devices, "devicename");
+              sortExpectedGroups[count].Users = sortArrayOn(sortExpectedGroups[count].Users, "username");
+              sortExpectedGroups[count].GroupUsers = sortArrayOn(sortExpectedGroups[count].GroupUsers, "userId");
+	    };
+	  }
+          checkTreeStructuresAreEqualExcept(
+            sortExpectedGroups,
+            sortGroups,
+            excludeCheckOn
+          );
+        }
+    });
+});
+
+Cypress.Commands.add(
+  "apiGroupsCheck",
+  (userName: string, where: any,  expectedGroups: ApiGroupReturned[], excludeCheckOn: string[] = [], statusCode: number = 200, additionalChecks: any = {}) => {
+    let sortGroups:ApiGroupReturned[];
+    let sortExpectedGroups:ApiGroupReturned[];
+
+    logTestDescription(
+      `${userName} Check groups accessible for user`,
+      { user: userName },
+      true
+    );
+   const params = {
+      where: JSON.stringify(where),
+    };
+
+    const fullUrl = v1ApiPath(`groups`,params);
+
+    //send the request
+    makeAuthorizedRequestWithStatus(
+      { url: fullUrl },
+      userName,
+      statusCode
+    ).then((response) => {
+        if (statusCode === 200) {
+          //sort expected and actual events into same order (means groupName, devicename, username, userId is mandatory in expectedGroup)
+          if (additionalChecks["doNotSort"] === true) {
+            sortGroups = response.body.groups;
+            sortExpectedGroups = expectedGroups;
+          } else {
+            sortGroups = sortArrayOn(response.body.groups, "groupName");
+            sortExpectedGroups = sortArrayOn(expectedGroups, "groupName");
+            for (let count=0; count < sortGroups.length; count++) {
+              sortGroups[count].Devices = sortArrayOn(sortGroups[count].Devices, "devicename");
+              sortGroups[count].Users = sortArrayOn(sortGroups[count].Users, "username");
+              sortGroups[count].GroupUsers = sortArrayOn(sortGroups[count].GroupUsers, "userId");
+            };
+            for (let count=0; count < sortExpectedGroups.length; count++) {
+              sortExpectedGroups[count].Devices = sortArrayOn(sortExpectedGroups[count].Devices, "devicename");
+              sortExpectedGroups[count].Users = sortArrayOn(sortExpectedGroups[count].Users, "username");
+              sortExpectedGroups[count].GroupUsers = sortArrayOn(sortExpectedGroups[count].GroupUsers, "userId");
+	    };
+	  }
+
+          checkTreeStructuresAreEqualExcept(
+            sortExpectedGroups,
+            sortGroups,
+            excludeCheckOn
+          );
+        }
+    });
+});
+
+Cypress.Commands.add(
+  "apiGroupsDevicesCheck",
+  (userName: string, groupNameOrId: any,  expectedDevices: ApiGroupsDevice[], excludeCheckOn: string[] = [], statusCode: number = 200, additionalChecks: any = {}) => {
+    let sortDevices:ApiGroupsDevice[];
+    let sortExpectedDevices:ApiGroupsDevice[];
+    let fullGroupName:string;
+
+    //Make group name unique unless we're asked not to
+    if(additionalChecks["useRawGroupName"]===true) {
+      fullGroupName = groupNameOrId;
+    } else {
+      fullGroupName = getTestName(groupNameOrId);
+    }
+
+    logTestDescription(
+      `${userName} Check group's devices for group ${groupNameOrId}`,
+      { user: userName },
+      true
+    );
+
+    const fullUrl = v1ApiPath(`groups/${fullGroupName}/devices`);
+
+    //send the request
+    makeAuthorizedRequestWithStatus(
+      { url: fullUrl },
+      userName,
+      statusCode
+    ).then((response) => {
+        if (statusCode === 200) {
+          //sort expected and actual events into same order (means groupName, devicename, username, userId is mandatory in expectedGroup)
+          if (additionalChecks["doNotSort"] === true) {
+            sortDevices = response.body.devices;
+            sortExpectedDevices = expectedDevices;
+          } else {
+            sortDevices = sortArrayOn(response.body.devices, "devicename");
+            sortExpectedDevices = sortArrayOn(expectedDevices, "devicename");
+          }
+
+          checkTreeStructuresAreEqualExcept(
+            sortExpectedDevices,
+            sortDevices,
+            excludeCheckOn
+          );
+        }
+    });
+});
+
+Cypress.Commands.add(
+  "apiGroupsStationsUpdate",
+    ( userName: string, groupIdOrName: string, stations: ApiStationData[], updateFrom?: string, statusCode: number = 200, additionalChecks: any = {}) => {
+      let fullGroupName:string;
+
+      //Make group name unique unless we're asked not to
+      if(additionalChecks["useRawGroupName"]===true) {
+        fullGroupName = groupIdOrName;
+      } else {
+        fullGroupName = getTestName(groupIdOrName);
+      }
+
+    logTestDescription(
+      `Add stations ${prettyLog(stations)} to group '${groupIdOrName}' `,
+      { userName, groupIdOrName, stations, updateFrom }
+    );
+
+    const body: { [key: string]: string } = {
+      stations: JSON.stringify(stations),
+    };
+    if (updateFrom!==undefined) {
+      body["fromDate"] = updateFrom;
+    }
+
+    makeAuthorizedRequestWithStatus(
+      {
+        method: "POST",
+        url: v1ApiPath(`groups/${fullGroupName}/stations`),
+        body,
+      },
+      userName,
+      statusCode
+    );
+  }
+);
+
+Cypress.Commands.add(
+  "apiGroupsStationsCheck",
+  (userName: string, groupIdOrName: string, expectedStations: ApiStationDataReturned[], excludeCheckOn: any = [], statusCode: number = 200, additionalChecks: any ={}) => {
+    logTestDescription(`Check stations for group ${groupIdOrName}`, {
+      userName,
+      groupIdOrName,
+    });
+    let fullGroupName:string;
+    let sortStations: ApiStationDataReturned[];
+    let sortExpectedStations: ApiStationDataReturned[];
+
+    //Make group name unique unless we're asked not to
+    if(additionalChecks["useRawGroupName"]===true) {
+      fullGroupName = groupIdOrName;
+    } else {
+      fullGroupName = getTestName(groupIdOrName);
+    }
+
+
+    makeAuthorizedRequestWithStatus(
+      {
+        method: "GET",
+        url: v1ApiPath(`groups/${fullGroupName}/stations`),
+      },
+      userName,
+      statusCode
+    ).then((response) => {
+      if (statusCode === 200) {
+        //sort expected and actual events into same order (means groupName, devicename, username, userId is mandatory in   expectedGroup)
+        if (additionalChecks["doNotSort"] === true) {
+          sortStations = response.body.stations;
+          sortExpectedStations = expectedStations;
+        } else {
+          sortStations = sortArrayOn(response.body.stations, "location");
+          sortExpectedStations = sortArrayOn(expectedStations, "location");
+        }
+
+        checkTreeStructuresAreEqualExcept(
+          sortExpectedStations,
+          sortStations,
+          excludeCheckOn
+        );
+      }
+    });
+
+  }
+);
+
+/*******************************************************************************************************
+ * Following are legacy test functions from old tests. The above standard-format API wrappers should be used in
+ * preference to these functions.  These may be deleted in the future
+*****************************************************************************************************/
+
+
+Cypress.Commands.add(
+  "apiGroupUserCheckAccess",
+  (userName: string, groupName: string, testForSuccess: boolean = true) => {
+    const user = getCreds(userName);
+    const fullGroupname = getTestName(groupName);
     const fullUrl = v1ApiPath("") + encodeURI("groups?where={}");
 
     logTestDescription(
-      `${username} Check user '${username}' can see group '${groupname}' `,
-      { user: username, groupname },
+      `${userName} Check user '${userName}' can see group '${groupName}' `,
+      { user: userName, groupName },
       true
     );
 
@@ -104,24 +428,3 @@ Cypress.Commands.add(
   }
 );
 
-Cypress.Commands.add(
-  "apiCreateGroup",
-  (userName: string, group: string, log = true) => {
-    logTestDescription(
-      `Create group '${group}' for user '${userName}'`,
-      { user: userName, group: group },
-      log
-    );
-
-    makeAuthorizedRequest(
-      {
-        method: "POST",
-        url: v1ApiPath("groups"),
-        body: { groupname: getTestName(group) },
-      },
-      userName
-    ).then((response) => {
-      saveIdOnly(group, response.body.groupId);
-    });
-  }
-);

--- a/integration-tests/cypress/commands/api/group.ts
+++ b/integration-tests/cypress/commands/api/group.ts
@@ -263,7 +263,7 @@ Cypress.Commands.add(
 });
 
 Cypress.Commands.add(
-  "apiGroupsDevicesCheck",
+  "apiGroupDevicesCheck",
   (userName: string, groupNameOrId: any,  expectedDevices: ApiGroupsDevice[], excludeCheckOn: string[] = [], statusCode: number = 200, additionalChecks: any = {}) => {
     let sortDevices:ApiGroupsDevice[];
     let sortExpectedDevices:ApiGroupsDevice[];
@@ -310,7 +310,7 @@ Cypress.Commands.add(
 });
 
 Cypress.Commands.add(
-  "apiGroupsStationsUpdate",
+  "apiGroupStationsUpdate",
     ( userName: string, groupIdOrName: string, stations: ApiStationData[], updateFrom?: string, statusCode: number = 200, additionalChecks: any = {}) => {
       let fullGroupName:string;
 
@@ -400,7 +400,7 @@ Cypress.Commands.add(
 
 
 Cypress.Commands.add(
-  "apiGroupUserCheckAccess",
+  "testGroupUserCheckAccess",
   (userName: string, groupName: string, testForSuccess: boolean = true) => {
     const user = getCreds(userName);
     const fullGroupname = getTestName(groupName);

--- a/integration-tests/cypress/commands/api/group.ts
+++ b/integration-tests/cypress/commands/api/group.ts
@@ -445,14 +445,14 @@ Cypress.Commands.add(
       userName,
       statusCode
     ).then((response) => {
-      if(additionalChecks["warnings"]) {
-         let warnings=response.body.warnings;
-         let expectedWarnings=additionalChecks["warnings"];
-         expect(warnings).to.exist;
-         expectedWarnings.forEach(function(warning:string) {
-           expect(warnings, 'Expect warning to be present').to.contain(warning);
-         });
-      }; 
+      if (additionalChecks["warnings"]) {
+        const warnings = response.body.warnings;
+        const expectedWarnings = additionalChecks["warnings"];
+        expect(warnings).to.exist;
+        expectedWarnings.forEach(function (warning: string) {
+          expect(warnings, "Expect warning to be present").to.contain(warning);
+        });
+      }
     });
   }
 );

--- a/integration-tests/cypress/commands/api/group.ts
+++ b/integration-tests/cypress/commands/api/group.ts
@@ -10,6 +10,7 @@ import {
   saveIdOnly,
   v1ApiPath,
   sortArrayOn,
+  sortArrayOnHash,
   checkTreeStructuresAreEqualExcept,
 } from "../server";
 
@@ -443,7 +444,16 @@ Cypress.Commands.add(
       },
       userName,
       statusCode
-    );
+    ).then((response) => {
+      if(additionalChecks["warnings"]) {
+         let warnings=response.body.warnings;
+         let expectedWarnings=additionalChecks["warnings"];
+         expect(warnings).to.exist;
+         expectedWarnings.forEach(function(warning:string) {
+           expect(warnings, 'Expect warning to be present').to.contain(warning);
+         });
+      }; 
+    });
   }
 );
 
@@ -486,8 +496,8 @@ Cypress.Commands.add(
           sortStations = response.body.stations;
           sortExpectedStations = expectedStations;
         } else {
-          sortStations = sortArrayOn(response.body.stations, "location");
-          sortExpectedStations = sortArrayOn(expectedStations, "location");
+          sortStations = sortArrayOnHash(response.body.stations, "location");
+          sortExpectedStations = sortArrayOnHash(expectedStations, "location");
         }
 
         checkTreeStructuresAreEqualExcept(

--- a/integration-tests/cypress/commands/api/group.ts
+++ b/integration-tests/cypress/commands/api/group.ts
@@ -10,15 +10,30 @@ import {
   saveIdOnly,
   v1ApiPath,
   sortArrayOn,
-  sortArrayOnTwoKeys,
-  checkTreeStructuresAreEqualExcept
+  checkTreeStructuresAreEqualExcept,
 } from "../server";
 
-import { ApiGroupsUserReturned, ApiGroupReturned, ApiGroupsDevice, ApiStationData, ApiStationDataReturned } from "../types";
+import {
+  ApiGroupsUserReturned,
+  ApiGroupReturned,
+  ApiGroupsDevice,
+  ApiStationData,
+  ApiStationDataReturned,
+} from "../types";
 
-Cypress.Commands.add( "apiGroupUserAdd", ( groupAdminUser: string, userName: string, groupName: string, admin = false, log = true, statusCode: number = 200, additionalChecks: any = {}) => {
-    let fullGroupName:string;
-    if(additionalChecks["useRawGroupName"]===true) {
+Cypress.Commands.add(
+  "apiGroupUserAdd",
+  (
+    groupAdminUser: string,
+    userName: string,
+    groupName: string,
+    admin = false,
+    log = true,
+    statusCode: number = 200,
+    additionalChecks: any = {}
+  ) => {
+    let fullGroupName: string;
+    if (additionalChecks["useRawGroupName"] === true) {
       fullGroupName = groupName;
     } else {
       fullGroupName = getTestName(groupName);
@@ -49,9 +64,16 @@ Cypress.Commands.add( "apiGroupUserAdd", ( groupAdminUser: string, userName: str
 );
 
 Cypress.Commands.add(
-  "apiGroupUserRemove", ( groupAdminUser: string, userName: string, groupName: string, statusCode: number = 200, additionalChecks: any = {}) => {
-    let fullGroupName:string;
-    if(additionalChecks["useRawGroupName"]===true) {
+  "apiGroupUserRemove",
+  (
+    groupAdminUser: string,
+    userName: string,
+    groupName: string,
+    statusCode: number = 200,
+    additionalChecks: any = {}
+  ) => {
+    let fullGroupName: string;
+    if (additionalChecks["useRawGroupName"] === true) {
       fullGroupName = groupName;
     } else {
       fullGroupName = getTestName(groupName);
@@ -80,12 +102,19 @@ Cypress.Commands.add(
 
 Cypress.Commands.add(
   "apiGroupUsersCheck",
-  (userName: string, groupName: string,  expectedUsers: ApiGroupsUserReturned[], excludeCheckOn: string[] = [], statusCode: number = 200, additionalChecks: any = {}) => {
-    let fullGroupName:string;
-    let sortUsers:ApiGroupsUserReturned[];
-    let sortExpectedUsers:ApiGroupsUserReturned[];
+  (
+    userName: string,
+    groupName: string,
+    expectedUsers: ApiGroupsUserReturned[],
+    excludeCheckOn: string[] = [],
+    statusCode: number = 200,
+    additionalChecks: any = {}
+  ) => {
+    let fullGroupName: string;
+    let sortUsers: ApiGroupsUserReturned[];
+    let sortExpectedUsers: ApiGroupsUserReturned[];
 
-    if(additionalChecks["useRawGroupName"]===true) {
+    if (additionalChecks["useRawGroupName"] === true) {
       fullGroupName = groupName;
     } else {
       fullGroupName = getTestName(groupName);
@@ -105,35 +134,41 @@ Cypress.Commands.add(
       userName,
       statusCode
     ).then((response) => {
-        if (statusCode === 200) {
-          //sort expected and actual events into same order (means dateTime is mandatory in expectedEvents)
-          if (additionalChecks["doNotSort"] === true) {
-            sortUsers = response.body.users;
-            sortExpectedUsers = expectedUsers;
-          } else {
-            sortUsers = sortArrayOn(response.body.users, "userName");
-            sortExpectedUsers = sortArrayOn(expectedUsers, "userName");
-          }
-          checkTreeStructuresAreEqualExcept(
-            sortExpectedUsers,
-            sortUsers,
-            excludeCheckOn
-          );
+      if (statusCode === 200) {
+        //sort expected and actual events into same order (means dateTime is mandatory in expectedEvents)
+        if (additionalChecks["doNotSort"] === true) {
+          sortUsers = response.body.users;
+          sortExpectedUsers = expectedUsers;
+        } else {
+          sortUsers = sortArrayOn(response.body.users, "userName");
+          sortExpectedUsers = sortArrayOn(expectedUsers, "userName");
         }
+        checkTreeStructuresAreEqualExcept(
+          sortExpectedUsers,
+          sortUsers,
+          excludeCheckOn
+        );
+      }
     });
   }
 );
 
 Cypress.Commands.add(
   "apiGroupAdd",
-  (userName: string, groupName: string, log = true, statusCode:number = 200, additionalChecks: any = {}) => {
-      let fullGroupName:string;
+  (
+    userName: string,
+    groupName: string,
+    log = true,
+    statusCode: number = 200,
+    additionalChecks: any = {}
+  ) => {
+    let fullGroupName: string;
 
-      if(additionalChecks["useRawGroupName"]===true) {
-        fullGroupName = groupName;
-      } else {
-        fullGroupName = getTestName(groupName);
-      }
+    if (additionalChecks["useRawGroupName"] === true) {
+      fullGroupName = groupName;
+    } else {
+      fullGroupName = getTestName(groupName);
+    }
 
     logTestDescription(
       `Create group '${groupName}' for user '${userName}'`,
@@ -150,82 +185,115 @@ Cypress.Commands.add(
       userName,
       statusCode
     ).then((response) => {
-        if (statusCode === 200) {
-          saveIdOnly(groupName, response.body.groupId);
-	}
+      if (statusCode === 200) {
+        saveIdOnly(groupName, response.body.groupId);
+      }
     });
   }
 );
 
 Cypress.Commands.add(
   "apiGroupCheck",
-  (userName: string, groupNameOrId: string,  expectedGroups: ApiGroupReturned[], excludeCheckOn: string[] = [], statusCode: number = 200, additionalChecks: any = {}) => {
-    let sortGroups:ApiGroupReturned[];
-    let sortExpectedGroups:ApiGroupReturned[];
-    let fullGroupName:string;
+  (
+    userName: string,
+    groupNameOrId: string,
+    expectedGroups: ApiGroupReturned[],
+    excludeCheckOn: string[] = [],
+    statusCode: number = 200,
+    additionalChecks: any = {}
+  ) => {
+    let sortGroups: ApiGroupReturned[];
+    let sortExpectedGroups: ApiGroupReturned[];
+    let fullGroupName: string;
 
     //Make group name unique unless we're asked not to
-    if(additionalChecks["useRawGroupName"]===true) {
+    if (additionalChecks["useRawGroupName"] === true) {
       fullGroupName = groupNameOrId;
     } else {
       fullGroupName = getTestName(groupNameOrId);
     }
-  
+
     const fullUrl = v1ApiPath(`groups/${fullGroupName}`);
-  
+
     logTestDescription(
       `${userName} Check group '${groupNameOrId}' `,
       { user: userName, groupNameOrId },
       true
     );
-  
+
     //send the request
     makeAuthorizedRequestWithStatus(
       { url: fullUrl },
       userName,
       statusCode
     ).then((response) => {
-        if (statusCode === 200) {
-          //sort expected and actual events into same order (means groupName, devicename, username, userId is mandatory in expectedGroup)
-          if (additionalChecks["doNotSort"] === true) {
-            sortGroups = sortArrayOn(response.body.groups, "groupName");
-            sortExpectedGroups = sortArrayOn(expectedGroups, "groupName");
-            for (let count=0; count < sortGroups.length; count++) {
-              sortGroups[count].Devices = sortArrayOn(sortGroups[count].Devices, "devicename");
-              sortGroups[count].Users = sortArrayOn(sortGroups[count].Users, "username");
-              sortGroups[count].GroupUsers = sortArrayOn(sortGroups[count].GroupUsers, "userId");
-            };
-            for (let count=0; count < sortExpectedGroups.length; count++) {
-              sortExpectedGroups[count].Devices = sortArrayOn(sortExpectedGroups[count].Devices, "devicename");
-              sortExpectedGroups[count].Users = sortArrayOn(sortExpectedGroups[count].Users, "username");
-              sortExpectedGroups[count].GroupUsers = sortArrayOn(sortExpectedGroups[count].GroupUsers, "userId");
-	    };
-	  }
-          checkTreeStructuresAreEqualExcept(
-            sortExpectedGroups,
-            sortGroups,
-            excludeCheckOn
-          );
+      if (statusCode === 200) {
+        //sort expected and actual events into same order (means groupName, devicename, username, userId is mandatory in expectedGroup)
+        if (additionalChecks["doNotSort"] === true) {
+          sortGroups = sortArrayOn(response.body.groups, "groupName");
+          sortExpectedGroups = sortArrayOn(expectedGroups, "groupName");
+          for (let count = 0; count < sortGroups.length; count++) {
+            sortGroups[count].Devices = sortArrayOn(
+              sortGroups[count].Devices,
+              "devicename"
+            );
+            sortGroups[count].Users = sortArrayOn(
+              sortGroups[count].Users,
+              "username"
+            );
+            sortGroups[count].GroupUsers = sortArrayOn(
+              sortGroups[count].GroupUsers,
+              "userId"
+            );
+          }
+          for (let count = 0; count < sortExpectedGroups.length; count++) {
+            sortExpectedGroups[count].Devices = sortArrayOn(
+              sortExpectedGroups[count].Devices,
+              "devicename"
+            );
+            sortExpectedGroups[count].Users = sortArrayOn(
+              sortExpectedGroups[count].Users,
+              "username"
+            );
+            sortExpectedGroups[count].GroupUsers = sortArrayOn(
+              sortExpectedGroups[count].GroupUsers,
+              "userId"
+            );
+          }
         }
+        checkTreeStructuresAreEqualExcept(
+          sortExpectedGroups,
+          sortGroups,
+          excludeCheckOn
+        );
+      }
     });
-});
+  }
+);
 
 Cypress.Commands.add(
   "apiGroupsCheck",
-  (userName: string, where: any,  expectedGroups: ApiGroupReturned[], excludeCheckOn: string[] = [], statusCode: number = 200, additionalChecks: any = {}) => {
-    let sortGroups:ApiGroupReturned[];
-    let sortExpectedGroups:ApiGroupReturned[];
+  (
+    userName: string,
+    where: any,
+    expectedGroups: ApiGroupReturned[],
+    excludeCheckOn: string[] = [],
+    statusCode: number = 200,
+    additionalChecks: any = {}
+  ) => {
+    let sortGroups: ApiGroupReturned[];
+    let sortExpectedGroups: ApiGroupReturned[];
 
     logTestDescription(
       `${userName} Check groups accessible for user`,
       { user: userName },
       true
     );
-   const params = {
+    const params = {
       where: JSON.stringify(where),
     };
 
-    const fullUrl = v1ApiPath(`groups`,params);
+    const fullUrl = v1ApiPath(`groups`, params);
 
     //send the request
     makeAuthorizedRequestWithStatus(
@@ -233,44 +301,70 @@ Cypress.Commands.add(
       userName,
       statusCode
     ).then((response) => {
-        if (statusCode === 200) {
-          //sort expected and actual events into same order (means groupName, devicename, username, userId is mandatory in expectedGroup)
-          if (additionalChecks["doNotSort"] === true) {
-            sortGroups = response.body.groups;
-            sortExpectedGroups = expectedGroups;
-          } else {
-            sortGroups = sortArrayOn(response.body.groups, "groupName");
-            sortExpectedGroups = sortArrayOn(expectedGroups, "groupName");
-            for (let count=0; count < sortGroups.length; count++) {
-              sortGroups[count].Devices = sortArrayOn(sortGroups[count].Devices, "devicename");
-              sortGroups[count].Users = sortArrayOn(sortGroups[count].Users, "username");
-              sortGroups[count].GroupUsers = sortArrayOn(sortGroups[count].GroupUsers, "userId");
-            };
-            for (let count=0; count < sortExpectedGroups.length; count++) {
-              sortExpectedGroups[count].Devices = sortArrayOn(sortExpectedGroups[count].Devices, "devicename");
-              sortExpectedGroups[count].Users = sortArrayOn(sortExpectedGroups[count].Users, "username");
-              sortExpectedGroups[count].GroupUsers = sortArrayOn(sortExpectedGroups[count].GroupUsers, "userId");
-	    };
-	  }
-
-          checkTreeStructuresAreEqualExcept(
-            sortExpectedGroups,
-            sortGroups,
-            excludeCheckOn
-          );
+      if (statusCode === 200) {
+        //sort expected and actual events into same order (means groupName, devicename, username, userId is mandatory in expectedGroup)
+        if (additionalChecks["doNotSort"] === true) {
+          sortGroups = response.body.groups;
+          sortExpectedGroups = expectedGroups;
+        } else {
+          sortGroups = sortArrayOn(response.body.groups, "groupName");
+          sortExpectedGroups = sortArrayOn(expectedGroups, "groupName");
+          for (let count = 0; count < sortGroups.length; count++) {
+            sortGroups[count].Devices = sortArrayOn(
+              sortGroups[count].Devices,
+              "devicename"
+            );
+            sortGroups[count].Users = sortArrayOn(
+              sortGroups[count].Users,
+              "username"
+            );
+            sortGroups[count].GroupUsers = sortArrayOn(
+              sortGroups[count].GroupUsers,
+              "userId"
+            );
+          }
+          for (let count = 0; count < sortExpectedGroups.length; count++) {
+            sortExpectedGroups[count].Devices = sortArrayOn(
+              sortExpectedGroups[count].Devices,
+              "devicename"
+            );
+            sortExpectedGroups[count].Users = sortArrayOn(
+              sortExpectedGroups[count].Users,
+              "username"
+            );
+            sortExpectedGroups[count].GroupUsers = sortArrayOn(
+              sortExpectedGroups[count].GroupUsers,
+              "userId"
+            );
+          }
         }
+
+        checkTreeStructuresAreEqualExcept(
+          sortExpectedGroups,
+          sortGroups,
+          excludeCheckOn
+        );
+      }
     });
-});
+  }
+);
 
 Cypress.Commands.add(
   "apiGroupDevicesCheck",
-  (userName: string, groupNameOrId: any,  expectedDevices: ApiGroupsDevice[], excludeCheckOn: string[] = [], statusCode: number = 200, additionalChecks: any = {}) => {
-    let sortDevices:ApiGroupsDevice[];
-    let sortExpectedDevices:ApiGroupsDevice[];
-    let fullGroupName:string;
+  (
+    userName: string,
+    groupNameOrId: any,
+    expectedDevices: ApiGroupsDevice[],
+    excludeCheckOn: string[] = [],
+    statusCode: number = 200,
+    additionalChecks: any = {}
+  ) => {
+    let sortDevices: ApiGroupsDevice[];
+    let sortExpectedDevices: ApiGroupsDevice[];
+    let fullGroupName: string;
 
     //Make group name unique unless we're asked not to
-    if(additionalChecks["useRawGroupName"]===true) {
+    if (additionalChecks["useRawGroupName"] === true) {
       fullGroupName = groupNameOrId;
     } else {
       fullGroupName = getTestName(groupNameOrId);
@@ -290,36 +384,44 @@ Cypress.Commands.add(
       userName,
       statusCode
     ).then((response) => {
-        if (statusCode === 200) {
-          //sort expected and actual events into same order (means groupName, devicename, username, userId is mandatory in expectedGroup)
-          if (additionalChecks["doNotSort"] === true) {
-            sortDevices = response.body.devices;
-            sortExpectedDevices = expectedDevices;
-          } else {
-            sortDevices = sortArrayOn(response.body.devices, "devicename");
-            sortExpectedDevices = sortArrayOn(expectedDevices, "devicename");
-          }
-
-          checkTreeStructuresAreEqualExcept(
-            sortExpectedDevices,
-            sortDevices,
-            excludeCheckOn
-          );
+      if (statusCode === 200) {
+        //sort expected and actual events into same order (means groupName, devicename, username, userId is mandatory in expectedGroup)
+        if (additionalChecks["doNotSort"] === true) {
+          sortDevices = response.body.devices;
+          sortExpectedDevices = expectedDevices;
+        } else {
+          sortDevices = sortArrayOn(response.body.devices, "devicename");
+          sortExpectedDevices = sortArrayOn(expectedDevices, "devicename");
         }
+
+        checkTreeStructuresAreEqualExcept(
+          sortExpectedDevices,
+          sortDevices,
+          excludeCheckOn
+        );
+      }
     });
-});
+  }
+);
 
 Cypress.Commands.add(
   "apiGroupStationsUpdate",
-    ( userName: string, groupIdOrName: string, stations: ApiStationData[], updateFrom?: string, statusCode: number = 200, additionalChecks: any = {}) => {
-      let fullGroupName:string;
+  (
+    userName: string,
+    groupIdOrName: string,
+    stations: ApiStationData[],
+    updateFrom?: string,
+    statusCode: number = 200,
+    additionalChecks: any = {}
+  ) => {
+    let fullGroupName: string;
 
-      //Make group name unique unless we're asked not to
-      if(additionalChecks["useRawGroupName"]===true) {
-        fullGroupName = groupIdOrName;
-      } else {
-        fullGroupName = getTestName(groupIdOrName);
-      }
+    //Make group name unique unless we're asked not to
+    if (additionalChecks["useRawGroupName"] === true) {
+      fullGroupName = groupIdOrName;
+    } else {
+      fullGroupName = getTestName(groupIdOrName);
+    }
 
     logTestDescription(
       `Add stations ${prettyLog(stations)} to group '${groupIdOrName}' `,
@@ -329,7 +431,7 @@ Cypress.Commands.add(
     const body: { [key: string]: string } = {
       stations: JSON.stringify(stations),
     };
-    if (updateFrom!==undefined) {
+    if (updateFrom !== undefined) {
       body["fromDate"] = updateFrom;
     }
 
@@ -347,22 +449,28 @@ Cypress.Commands.add(
 
 Cypress.Commands.add(
   "apiGroupsStationsCheck",
-  (userName: string, groupIdOrName: string, expectedStations: ApiStationDataReturned[], excludeCheckOn: any = [], statusCode: number = 200, additionalChecks: any ={}) => {
+  (
+    userName: string,
+    groupIdOrName: string,
+    expectedStations: ApiStationDataReturned[],
+    excludeCheckOn: any = [],
+    statusCode: number = 200,
+    additionalChecks: any = {}
+  ) => {
     logTestDescription(`Check stations for group ${groupIdOrName}`, {
       userName,
       groupIdOrName,
     });
-    let fullGroupName:string;
+    let fullGroupName: string;
     let sortStations: ApiStationDataReturned[];
     let sortExpectedStations: ApiStationDataReturned[];
 
     //Make group name unique unless we're asked not to
-    if(additionalChecks["useRawGroupName"]===true) {
+    if (additionalChecks["useRawGroupName"] === true) {
       fullGroupName = groupIdOrName;
     } else {
       fullGroupName = getTestName(groupIdOrName);
     }
-
 
     makeAuthorizedRequestWithStatus(
       {
@@ -389,15 +497,13 @@ Cypress.Commands.add(
         );
       }
     });
-
   }
 );
 
 /*******************************************************************************************************
  * Following are legacy test functions from old tests. The above standard-format API wrappers should be used in
  * preference to these functions.  These may be deleted in the future
-*****************************************************************************************************/
-
+ *****************************************************************************************************/
 
 Cypress.Commands.add(
   "testGroupUserCheckAccess",
@@ -427,4 +533,3 @@ Cypress.Commands.add(
     });
   }
 );
-

--- a/integration-tests/cypress/commands/api/recording.d.ts
+++ b/integration-tests/cypress/commands/api/recording.d.ts
@@ -65,7 +65,7 @@ declare namespace Cypress {
     /**
      * Check recording count for device matches expected value
      */
-    apiCheckDeviceHasRecordings(
+    testCheckDeviceHasRecordings(
       userName: string,
       deviceName: string,
       count: number

--- a/integration-tests/cypress/commands/api/recording.d.ts
+++ b/integration-tests/cypress/commands/api/recording.d.ts
@@ -53,7 +53,7 @@ declare namespace Cypress {
      * upload a single recording to for a particular camera using pre-rolled test metadata
      * Optionally, save the id against provided recordingName
      */
-    testRecordingAddWithTestData(
+    testUploadRecording(
       deviceName: string,
       details: TestThermalRecordingInfo,
       log?: boolean,

--- a/integration-tests/cypress/commands/api/recording.d.ts
+++ b/integration-tests/cypress/commands/api/recording.d.ts
@@ -1,9 +1,10 @@
 // load the global Cypress types
 /// <reference types="cypress" />
-/// <reference types="../types" />
 
 declare namespace Cypress {
-  type ApiThermalRecordingInfo = import("../types").ApiThermalRecordingInfo;
+  type TestThermalRecordingInfo = import("../types").TestThermalRecordingInfo;
+  type ApiRecordingData = import("../types").ApiRecordingData;
+  type ApiRecordingDataMetadata = import("../types").ApiRecordingDataMetadata;
   type Interception = import("cypress/types/net-stubbing").Interception;
   type RecordingId = number;
 
@@ -12,10 +13,10 @@ declare namespace Cypress {
      * upload a single recording to for a particular camera using deviceId and user credentials
      * Optionally, save the id against provided recordingName
      */
-    uploadRecordingOnBehalfUsingDevice(
+    apiRecordingAddOnBehalfUsingDevice(
       deviceName: string,
       userName: string,
-      details: ApiThermalRecordingInfo,
+      details: TestThermalRecordingInfo,
       log?: boolean,
       recordingName?: string
     ): Cypress.Chainable<RecordingId>;
@@ -24,42 +25,59 @@ declare namespace Cypress {
      * upload a single recording to for a particular camera using devicename and groupname and user credentials
      * Optionally, save the id against provided recordingName
      */
-    uploadRecordingOnBehalfUsingGroup(
+    apiRecordingAddOnBehalfUsingGroup(
       deviceName: string,
       groupName: string,
       userName: string,
-      details: ApiThermalRecordingInfo,
-      log?: boolean,
-      recordingName?: string
-    ): Cypress.Chainable<RecordingId>;
-    /**
-     * upload a single recording to for a particular camera
-     * Optionally, save the id against provided recordingName
-     */
-    uploadRecording(
-      deviceName: string,
-      details: ApiThermalRecordingInfo,
+      details: TestThermalRecordingInfo,
       log?: boolean,
       recordingName?: string
     ): Cypress.Chainable<RecordingId>;
 
-    uploadRecordingThenUserTag(
+    /**
+     * Upload a single recording using device credentials
+     * Save the provided ID against the provided recording name
+     * Optionally, check for a non-200 return statusCode
+     */
+    apiRecordingAdd(
+      recordingName: string,
       deviceName: string,
-      details: ApiThermalRecordingInfo,
+      data: ApiRecordingData,
+      fileName: string,
+      metadata: ApiRecordingDataMetadata,
+      statusCode: number,
+      additionalChecks: any
+    ): any;
+
+    /**
+     * upload a single recording to for a particular camera using pre-rolled test metadata
+     * Optionally, save the id against provided recordingName
+     */
+    testRecordingAddWithTestData(
+      deviceName: string,
+      details: TestThermalRecordingInfo,
+      log?: boolean,
+      recordingName?: string,
+      statusCode?: number
+    ): Cypress.Chainable<RecordingId>;
+
+    testAddRecordingThenUserTag(
+      deviceName: string,
+      details: TestThermalRecordingInfo,
       tagger: string,
       tag: string
     ): any;
 
-    userTagRecording(
+    testUserTagRecording(
       recordingId: number,
       trackIndex: number,
       tagger: string,
       tag: string
     ): any;
 
-    uploadRecordingsAtTimes(deviceName: string, times: string[]): any;
+    testAddRecordingsAtTimes(deviceName: string, times: string[]): any;
 
-    // to be run straight after an uploadRecording
+    // to be run straight after an apiRecordingAdd
     thenUserTagAs(tagger: string, tag: string): any;
 
     /**

--- a/integration-tests/cypress/commands/api/recording.ts
+++ b/integration-tests/cypress/commands/api/recording.ts
@@ -315,7 +315,7 @@ function addTracksToRecording(
 }
 
 Cypress.Commands.add(
-  "apiCheckDeviceHasRecordings",
+  "testCheckDeviceHasRecordings",
   (userName, deviceName, count) => {
     const user = getCreds(userName);
     const camera = getCreds(deviceName);

--- a/integration-tests/cypress/commands/api/recording.ts
+++ b/integration-tests/cypress/commands/api/recording.ts
@@ -55,7 +55,7 @@ Cypress.Commands.add(
 );
 
 Cypress.Commands.add(
-  "testRecordingAddWithTestData",
+  "testUploadRecording",
   (
     deviceName: string,
     details: TestThermalRecordingInfo,
@@ -168,7 +168,7 @@ Cypress.Commands.add(
     );
 
     times.forEach((time) => {
-      cy.testRecordingAddWithTestData(deviceName, { time }, false);
+      cy.testUploadRecording(deviceName, { time }, false);
     });
   }
 );
@@ -220,7 +220,7 @@ Cypress.Commands.add(
     tagger: string,
     tag: string
   ) => {
-    cy.testRecordingAddWithTestData(deviceName, details).then((recordingId) => {
+    cy.testUploadRecording(deviceName, details).then((recordingId) => {
       cy.testUserTagRecording(recordingId, 0, tagger, tag);
     });
   }

--- a/integration-tests/cypress/commands/api/stations.d.ts
+++ b/integration-tests/cypress/commands/api/stations.d.ts
@@ -3,7 +3,7 @@
 
 declare namespace Cypress {
   interface Chainable {
-    // to be run straight after an uploadRecording
+    // to be run straight after an apiRecordingAdd
     // check that the recording has been assigned the right station name. sS
     thenCheckStationIs(userName: string, station: string): any;
 

--- a/integration-tests/cypress/commands/api/stations.d.ts
+++ b/integration-tests/cypress/commands/api/stations.d.ts
@@ -2,27 +2,7 @@
 /// <reference types="cypress" />
 
 declare namespace Cypress {
-  type ApiCreateStationData = import("../types").ApiCreateStationData;
   interface Chainable {
-    /**
-     * upload stations data for a group
-     */
-    apiUploadStations(
-      userName: string,
-      groupName: string,
-      stations: ApiCreateStationData[],
-      updateFrom?: Date
-    ): any;
-
-    /**
-     * upload stations data for a group
-     */
-    apiCheckStations(
-      userName: string,
-      groupName: string,
-      stations: ApiCreateStationData[]
-    ): any;
-
     // to be run straight after an uploadRecording
     // check that the recording has been assigned the right station name. sS
     thenCheckStationIs(userName: string, station: string): any;

--- a/integration-tests/cypress/commands/api/stations.ts
+++ b/integration-tests/cypress/commands/api/stations.ts
@@ -1,63 +1,10 @@
 // load the global Cypress types
 /// <reference types="cypress" />
 
-import { v1ApiPath, makeAuthorizedRequest } from "../server";
-import { logTestDescription, prettyLog } from "../descriptions";
-import { getTestName } from "../names";
+import { logTestDescription } from "../descriptions";
 import { checkRecording } from "./recording";
-import { ApiCreateStationData } from "../types";
 
-Cypress.Commands.add(
-  "apiUploadStations",
-  (
-    userName: string,
-    groupName: string,
-    stations: ApiCreateStationData[],
-    updateFrom?: Date
-  ) => {
-    logTestDescription(
-      `Add stations ${prettyLog(stations)} to group '${groupName}' `,
-      { userName, groupName, stations, updateFrom }
-    );
-
-    const actualGroup = getTestName(groupName);
-    const body: { [key: string]: string } = {
-      stations: JSON.stringify(stations),
-    };
-    if (updateFrom) {
-      body["fromDate"] = updateFrom.toISOString();
-    }
-
-    makeAuthorizedRequest(
-      {
-        method: "POST",
-        url: v1ApiPath(`groups/${actualGroup}/stations`),
-        body,
-      },
-      userName
-    );
-  }
-);
-
-Cypress.Commands.add(
-  "apiCheckStations",
-  (userName: string, groupName: string) => {
-    logTestDescription(`Check stations for group ${groupName}`, {
-      userName,
-      groupName,
-    });
-
-    const actualGroup = getTestName(groupName);
-
-    makeAuthorizedRequest(
-      {
-        method: "GET",
-        url: v1ApiPath(`groups/${actualGroup}/stations`),
-      },
-      userName
-    );
-  }
-);
+// Legacy test functions used in /recordings. To be retired and replaces with standard-format API wrappers.
 
 Cypress.Commands.add(
   "thenCheckStationIs",

--- a/integration-tests/cypress/commands/api/user.d.ts
+++ b/integration-tests/cypress/commands/api/user.d.ts
@@ -11,7 +11,7 @@ declare namespace Cypress {
     /**
      * create a group for the given user (who has already been referenced in the test
      */
-    apiCreateGroup(userName: string, groupName: string, log?: boolean): any;
+    apiGroupAdd(userName: string, groupName: string, log?: boolean): any;
 
     /**
      * create user group and camera at the same time
@@ -30,7 +30,7 @@ declare namespace Cypress {
     /**
      * create user group and camera at the same time
      */
-    apiCreateGroupAndDevices(
+    apiGroupAddAndDevices(
       userName: string,
       group: string,
       ...cameras: string[]

--- a/integration-tests/cypress/commands/api/user.d.ts
+++ b/integration-tests/cypress/commands/api/user.d.ts
@@ -6,7 +6,7 @@ declare namespace Cypress {
     /**
      * create user and save api credentials further use
      */
-    apiCreateUser(userName: string, log?: boolean): any;
+    apiUserAdd(userName: string, log?: boolean): any;
 
     /**
      * create a group for the given user (who has already been referenced in the test
@@ -16,7 +16,7 @@ declare namespace Cypress {
     /**
      * create user group and camera at the same time
      */
-    apiCreateUserGroupAndDevice(
+    testCreateUserGroupAndDevice(
       userName: string,
       group: string,
       camera: string
@@ -25,12 +25,12 @@ declare namespace Cypress {
     /**
      * create user group and camera at the same time
      */
-    apiCreateUserGroup(userName: string, group: string): any;
+    testCreateUserAndGroup(userName: string, group: string): any;
 
     /**
      * create user group and camera at the same time
      */
-    apiGroupAddAndDevices(
+    testCreateGroupAndDevices(
       userName: string,
       group: string,
       ...cameras: string[]

--- a/integration-tests/cypress/commands/api/user.ts
+++ b/integration-tests/cypress/commands/api/user.ts
@@ -34,7 +34,7 @@ Cypress.Commands.add(
       { user: userName, group: group, camera: camera }
     );
     cy.apiCreateUser(userName, false);
-    cy.apiCreateGroup(userName, group, false);
+    cy.apiGroupAdd(userName, group, false);
     cy.apiCreateDevice(camera, group, null, null);
   }
 );
@@ -45,11 +45,11 @@ Cypress.Commands.add("apiCreateUserGroup", (userName, group) => {
     group: group,
   });
   cy.apiCreateUser(userName, false);
-  cy.apiCreateGroup(userName, group, false);
+  cy.apiGroupAdd(userName, group, false);
 });
 
 Cypress.Commands.add(
-  "apiCreateGroupAndDevices",
+  "apiGroupAddAndDevices",
   (userName, group, ...cameras) => {
     logTestDescription(
       `Create group '${group}' with cameras '${prettyLog(cameras)}'`,
@@ -59,7 +59,7 @@ Cypress.Commands.add(
         cameras,
       }
     );
-    cy.apiCreateGroup(userName, group, false);
+    cy.apiGroupAdd(userName, group, false);
     cameras.forEach((camera) => {
       cy.apiCreateDevice(camera, group);
     });

--- a/integration-tests/cypress/commands/api/user.ts
+++ b/integration-tests/cypress/commands/api/user.ts
@@ -5,7 +5,7 @@ import { getTestName } from "../names";
 import { apiPath, saveCreds } from "../server";
 import { logTestDescription, prettyLog } from "../descriptions";
 
-Cypress.Commands.add("apiCreateUser", (userName: string, log = true) => {
+Cypress.Commands.add("apiUserAdd", (userName: string, log = true) => {
   logTestDescription(`Create user '${userName}'`, { user: userName }, log);
 
   const usersUrl = apiPath() + "/api/v1/users";
@@ -27,29 +27,29 @@ Cypress.Commands.add("apiCreateUser", (userName: string, log = true) => {
 });
 
 Cypress.Commands.add(
-  "apiCreateUserGroupAndDevice",
+  "testCreateUserGroupAndDevice",
   (userName, group, camera) => {
     logTestDescription(
       `Create user '${userName}' with camera '${camera}' in group '${group}'`,
       { user: userName, group: group, camera: camera }
     );
-    cy.apiCreateUser(userName, false);
+    cy.apiUserAdd(userName, false);
     cy.apiGroupAdd(userName, group, false);
-    cy.apiCreateDevice(camera, group, null, null);
+    cy.apiDeviceAdd(camera, group, null, null);
   }
 );
 
-Cypress.Commands.add("apiCreateUserGroup", (userName, group) => {
+Cypress.Commands.add("testCreateUserAndGroup", (userName, group) => {
   logTestDescription(`Create user '${userName}' with group '${group}'`, {
     user: userName,
     group: group,
   });
-  cy.apiCreateUser(userName, false);
+  cy.apiUserAdd(userName, false);
   cy.apiGroupAdd(userName, group, false);
 });
 
 Cypress.Commands.add(
-  "apiGroupAddAndDevices",
+  "testCreateGroupAndDevices",
   (userName, group, ...cameras) => {
     logTestDescription(
       `Create group '${group}' with cameras '${prettyLog(cameras)}'`,
@@ -61,7 +61,7 @@ Cypress.Commands.add(
     );
     cy.apiGroupAdd(userName, group, false);
     cameras.forEach((camera) => {
-      cy.apiCreateDevice(camera, group);
+      cy.apiDeviceAdd(camera, group);
     });
   }
 );

--- a/integration-tests/cypress/commands/constants.ts
+++ b/integration-tests/cypress/commands/constants.ts
@@ -3,4 +3,4 @@ export const HTTP_Forbidden = 403;
 export const HTTP_BadRequest = 400;
 export const HTTP_Unprocessable = 422;
 export const HTTP_OK200 = 200;
-export const NOT_NULL="not null";
+export const NOT_NULL = "not null";

--- a/integration-tests/cypress/commands/constants.ts
+++ b/integration-tests/cypress/commands/constants.ts
@@ -3,3 +3,4 @@ export const HTTP_Forbidden = 403;
 export const HTTP_BadRequest = 400;
 export const HTTP_Unprocessable = 422;
 export const HTTP_OK200 = 200;
+export const NOT_NULL="not null";

--- a/integration-tests/cypress/commands/server.ts
+++ b/integration-tests/cypress/commands/server.ts
@@ -144,12 +144,25 @@ export function checkResponse(response: Cypress.Response<any>, code: number) {
   return response;
 }
 
-export function sortArrayOn(theArray: any, theKey: string) {
+export function sortArrayOnHash(theArray: any, theKey: string) {
   theArray.sort(function (a: any, b: any) {
     if (JSON.stringify(a[theKey]) < JSON.stringify(b[theKey])) {
       return -1;
     }
     if (JSON.stringify(a[theKey]) > JSON.stringify(b[theKey])) {
+      return 1;
+    }
+    return 0;
+  });
+  return theArray;
+}
+
+export function sortArrayOn(theArray: any, theKey: string) {
+  theArray.sort(function (a: any, b: any) {
+    if (a[theKey] < b[theKey]) {
+      return -1;
+    }
+    if (a[theKey] > b[theKey]) {
       return 1;
     }
     return 0;

--- a/integration-tests/cypress/commands/server.ts
+++ b/integration-tests/cypress/commands/server.ts
@@ -271,10 +271,11 @@ export function checkTreeStructuresAreEqualExcept(
             );
           } else {
             //check we were aksed to validate, or validate NOT NULL
-            if(containedStruct[containedKeys[count]]==NOT_NULL) {
+            if (containedStruct[containedKeys[count]] == NOT_NULL) {
               expect(
                 containingStruct[containedKeys[count]],
-                `Expected ${prettyElementName} should not be NULL`).to.not.be.null;
+                `Expected ${prettyElementName} should not be NULL`
+              ).to.not.be.null;
             } else {
               //otherwise, check the values are as expected
               expect(
@@ -283,7 +284,7 @@ export function checkTreeStructuresAreEqualExcept(
                   containedStruct[containedKeys[count]]
                 )}`
               ).to.equal(containedStruct[containedKeys[count]]);
-            };
+            }
           }
         }
       }

--- a/integration-tests/cypress/commands/server.ts
+++ b/integration-tests/cypress/commands/server.ts
@@ -1,9 +1,10 @@
 // load the global Cypress types
 /// <reference types="cypress" />
 export const DEFAULT_DATE = new Date(2021, 4, 9, 22);
-export const AuthorizationError = 402;
 
 import { format as urlFormat } from "url";
+
+import { NOT_NULL } from "./constants";
 
 export function apiPath(): string {
   return Cypress.env("cacophony-api-server");
@@ -145,10 +146,10 @@ export function checkResponse(response: Cypress.Response<any>, code: number) {
 
 export function sortArrayOn(theArray: any, theKey: string) {
   theArray.sort(function (a: any, b: any) {
-    if (a[theKey] < b[theKey]) {
+    if (JSON.stringify(a[theKey]) < JSON.stringify(b[theKey])) {
       return -1;
     }
-    if (a[theKey] > b[theKey]) {
+    if (JSON.stringify(a[theKey]) > JSON.stringify(b[theKey])) {
       return 1;
     }
     return 0;
@@ -269,13 +270,20 @@ export function checkTreeStructuresAreEqualExcept(
               prettyElementName
             );
           } else {
-            //otherwise, check the values are as expected
-            expect(
-              containingStruct[containedKeys[count]],
-              `Expected ${prettyElementName} should equal ${JSON.stringify(
-                containedStruct[containedKeys[count]]
-              )}`
-            ).to.equal(containedStruct[containedKeys[count]]);
+            //check we were aksed to validate, or validate NOT NULL
+            if(containedStruct[containedKeys[count]]==NOT_NULL) {
+              expect(
+                containingStruct[containedKeys[count]],
+                `Expected ${prettyElementName} should not be NULL`).to.not.be.null;
+            } else {
+              //otherwise, check the values are as expected
+              expect(
+                containingStruct[containedKeys[count]],
+                `Expected ${prettyElementName} should equal ${JSON.stringify(
+                  containedStruct[containedKeys[count]]
+                )}`
+              ).to.equal(containedStruct[containedKeys[count]]);
+            };
           }
         }
       }

--- a/integration-tests/cypress/commands/types.d.ts
+++ b/integration-tests/cypress/commands/types.d.ts
@@ -235,12 +235,45 @@ export interface ApiGroupUserRelation {
  * RECORDING definitions
  ********************************************************************/
 
-export interface ApiThermalRecordingInfo {
+// from api/v1/recordings (post)
+export interface ApiRecordingData {
+  type: string;
+  fileHash: string;
+  duration: number;
+  recordingDateTime: string;
+  location: ApiLocation;
+  version: string;
+  batteryCharging: boolean;
+  batteryLevel: number;
+  airplaneModeOn: boolean;
+  additionalMetadata: ApiRecordingDataMetadata;
+  comment: string;
+  processingState: string;
+}
+
+// from api/v1/recordings (post)
+export interface ApiRecordingDataMetadata {
+  tracks: ApiTrackSet;
+  algorythm?: string;
+}
+
+//from api/v1/recordings (post)
+export interface ApiTrackSet {
+  positions: number[][];
+  start_s: number;
+  end_s: number;
+  confident_tag?: string;
+  confidence: number;
+  all_class_confidences: any;
+}
+
+//Simplified test version of above structures for generic recordings
+export interface TestThermalRecordingInfo {
   processingState?: string;
   time?: Date | string;
   duration?: number;
   model?: string;
-  tracks?: ApiTrackInfo[];
+  tracks?: TestTrackInfo[];
   noTracks?: boolean; // by default there will normally be one track, set to true if you don't want tracks
   minsLater?: number; // minutes that later that the recording is taken
   secsLater?: number; // minutes that later that the recording is taken
@@ -249,7 +282,8 @@ export interface ApiThermalRecordingInfo {
   lng?: number; // Longitude position for the recording
 }
 
-export interface ApiTrackInfo {
+//Simplified test version of above structures for generic recordings
+export interface TestTrackInfo {
   start_s?: number;
   end_s?: number;
   tag?: string;
@@ -263,14 +297,17 @@ export interface ApiStationData {
   lng: number;
 }
 
+// from api/v1/groups/<>/stations (get), apiRecordings (post)
+export interface ApiLocation {
+  type: string;
+  coordinates: [number, number];
+}
+
 // from api/v1/groups/<>/stations (get)
 export interface ApiStationDataReturned {
   id: number;
   name: string;
-  location: {
-    type: string;
-    coordinates: [number, number];
-  };
+  location: ApiLocation;
   lastUpdatedById: number;
   createdAt: string;
   retiredAt: string;

--- a/integration-tests/cypress/commands/types.d.ts
+++ b/integration-tests/cypress/commands/types.d.ts
@@ -1,6 +1,6 @@
 /*******************************************************************
-* ALERT definitions            
-********************************************************************/
+ * ALERT definitions
+ ********************************************************************/
 // from api/v1/alerts (get)
 export interface ApiAlert {
   id: number;
@@ -10,7 +10,7 @@ export interface ApiAlert {
   conditions: ApiAlertConditions[];
   lastAlert: boolean;
   User: ApiAlertUser;
-  Device: ApiDeviceIdAndName
+  Device: ApiDeviceIdAndName;
 }
 
 // from api/v1/alerts (post)
@@ -28,8 +28,8 @@ export interface ApiAlertConditions {
 }
 
 /*******************************************************************
-* DEVICE definitions            
-********************************************************************/
+ * DEVICE definitions
+ ********************************************************************/
 // from api/v1/groups (get), api/v1/events (get)
 export interface ApiDeviceIdAndName {
   id: number;
@@ -66,8 +66,8 @@ export interface ApiDeviceQueryDevice {
   id: number;
   saltId?: number;
   Group: {
-   groupname: string;
-  }
+    groupname: string;
+  };
 }
 
 // from api/v1/authenticate/token (POST)
@@ -75,10 +75,9 @@ export interface ApiAuthenticateAccess {
   devices: string;
 }
 
-
 /*******************************************************************
-* USER definitions            
-********************************************************************/
+ * USER definitions
+ ********************************************************************/
 // from api/v1/alerts (get)
 export interface ApiAlertUser {
   id: number;
@@ -98,23 +97,23 @@ export interface ApiDeviceUsersUser {
 
 // from api/v1/groups (get)
 export interface ApiGroupUser {
-  username: string,
+  username: string;
   id: number;
-  isAdmin: boolean
+  isAdmin: boolean;
 }
 
 // api/v1/devices/.../in-group (get)
 export interface ApiDeviceUser {
-  userName: string,
+  userName: string;
   id: number;
-  isAdmin: boolean
+  isAdmin: boolean;
 }
 
 //from api/v1/groups/users (get)
 export interface ApiGroupsUserReturned {
-  userName: string,
+  userName: string;
   id: number;
-  isGroupAdmin: boolean
+  isGroupAdmin: boolean;
 }
 
 // from api/v1/devices
@@ -132,8 +131,8 @@ export interface ApiDeviceUserRelationship {
 }
 
 /*******************************************************************
-* EVENT definitions
-********************************************************************/
+ * EVENT definitions
+ ********************************************************************/
 
 // from /api/v1/events (get) and api/v1/events (post)
 export interface ApiEventDetail {
@@ -207,8 +206,8 @@ export interface ApiEventErrorCategory {
 }
 
 /*******************************************************************
-* GROUP definitions
-********************************************************************/
+ * GROUP definitions
+ ********************************************************************/
 
 // from api/v1/groups (get)
 export interface ApiGroupReturned {
@@ -224,18 +223,17 @@ export interface ApiGroupUserRelation {
   id: number;
   username: string;
   GroupUsers: {
-	  admin: boolean,
-	  createdAt: string,
-	  updatedAt: string,
-	  GroupId: number,
-	  UserId: number
-  }
+    admin: boolean;
+    createdAt: string;
+    updatedAt: string;
+    GroupId: number;
+    UserId: number;
+  };
 }
 
 /*******************************************************************
-* RECORDING definitions
-********************************************************************/
-
+ * RECORDING definitions
+ ********************************************************************/
 
 export interface ApiThermalRecordingInfo {
   processingState?: string;
@@ -269,10 +267,10 @@ export interface ApiStationData {
 export interface ApiStationDataReturned {
   id: number;
   name: string;
-  location: { 
-    type: string,
+  location: {
+    type: string;
     coordinates: [number, number];
-  },
+  };
   lastUpdatedById: number;
   createdAt: string;
   retiredAt: string;
@@ -280,10 +278,9 @@ export interface ApiStationDataReturned {
   GroupId: number;
 }
 
-
 /*******************************************************************
-* Custom structures used internally in test code
-********************************************************************/
+ * Custom structures used internally in test code
+ ********************************************************************/
 
 export interface TestComparableEvent {
   id: number;
@@ -333,4 +330,3 @@ export interface TestDeviceAndGroup {
   devicename: string;
   groupname: string;
 }
-

--- a/integration-tests/cypress/commands/types.d.ts
+++ b/integration-tests/cypress/commands/types.d.ts
@@ -1,20 +1,7 @@
-export interface ApiAlertConditions {
-  tag: string;
-  automatic: boolean;
-}
-
-export interface ApiAlertUser {
-  id: number;
-  username: string;
-  email: string;
-  name: string;
-}
-
-export interface ApiAlertDevice {
-  id: number;
-  devicename: string;
-}
-
+/*******************************************************************
+* ALERT definitions            
+********************************************************************/
+// from api/v1/alerts (get)
 export interface ApiAlert {
   id: number;
   name: string;
@@ -23,13 +10,39 @@ export interface ApiAlert {
   conditions: ApiAlertConditions[];
   lastAlert: boolean;
   User: ApiAlertUser;
-  Device: ApiAlertDevice;
+  Device: ApiDeviceIdAndName
 }
 
-export interface ApiAuthenticateAccess {
-  devices: string;
+// from api/v1/alerts (post)
+export interface ApiAlertSet {
+  name: string;
+  conditions: ApiAlertConditions[];
+  deviceId: number;
+  frequencySeconds: number;
 }
 
+// from api/v1/alerts (get) and (post)
+export interface ApiAlertConditions {
+  tag: string;
+  automatic: boolean;
+}
+
+/*******************************************************************
+* DEVICE definitions            
+********************************************************************/
+// from api/v1/groups (get), api/v1/events (get)
+export interface ApiDeviceIdAndName {
+  id: number;
+  devicename: string;
+}
+
+// from api/v1/groups/<>/devices (get)
+export interface ApiGroupsDevice {
+  id: number;
+  deviceName: string;
+}
+
+// from api/v1/devices (get)
 export interface ApiDevicesDevice {
   id: number;
   devicename: string;
@@ -37,43 +50,44 @@ export interface ApiDevicesDevice {
   Users: ApiDevicesDeviceUser[];
 }
 
+// from api/v1/devices/.../in-group/ (get)
 export interface ApiDeviceInGroupDevice {
   id: number;
   devicename: string;
   groupName: string;
   userIsAdmin: boolean;
-  users: ApiDeviceInGroupUser[];
+  users: ApiDeviceUser[];
 }
 
+//From api/v1/devices/query (get)
 export interface ApiDeviceQueryDevice {
   devicename: string;
   groupname: string;
+  id: number;
   saltId?: number;
+  Group: {
+   groupname: string;
+  }
 }
 
-export interface TestDeviceAndGroup {
-  devicename: string;
-  groupname: string;
+// from api/v1/authenticate/token (POST)
+export interface ApiAuthenticateAccess {
+  devices: string;
 }
 
-export interface ApiDevicesDeviceUser {
+
+/*******************************************************************
+* USER definitions            
+********************************************************************/
+// from api/v1/alerts (get)
+export interface ApiAlertUser {
   id: number;
   username: string;
-  DeviceUsers: ApiDeviceUserRelationship;
+  email: string;
+  name: string;
 }
 
-export interface ApiDeviceUserRelationship {
-  admin: boolean;
-  DeviceId: number;
-  UserId: number;
-}
-
-export interface ApiDeviceInGroupUser {
-  userName: string;
-  admin: boolean;
-  id: number;
-}
-
+// from api/v1/devices/users (get)
 export interface ApiDeviceUsersUser {
   id: number;
   username: string;
@@ -82,16 +96,52 @@ export interface ApiDeviceUsersUser {
   admin: boolean;
 }
 
-export interface TestComparablePowerEvent {
-  hasStopped: boolean;
-  hasAlerted: boolean;
+// from api/v1/groups (get)
+export interface ApiGroupUser {
+  username: string,
+  id: number;
+  isAdmin: boolean
 }
 
+// api/v1/devices/.../in-group (get)
+export interface ApiDeviceUser {
+  userName: string,
+  id: number;
+  isAdmin: boolean
+}
+
+//from api/v1/groups/users (get)
+export interface ApiGroupsUserReturned {
+  userName: string,
+  id: number;
+  isGroupAdmin: boolean
+}
+
+// from api/v1/devices
+export interface ApiDevicesDeviceUser {
+  id: number;
+  username: string;
+  DeviceUsers: ApiDeviceUserRelationship;
+}
+
+// from api/v1/devices
+export interface ApiDeviceUserRelationship {
+  admin: boolean;
+  DeviceId: number;
+  UserId: number;
+}
+
+/*******************************************************************
+* EVENT definitions
+********************************************************************/
+
+// from /api/v1/events (get) and api/v1/events (post)
 export interface ApiEventDetail {
   type?: string;
   details?: any;
 }
 
+// from api/v1/events (post)
 export interface ApiEventSet {
   deviceID?: string;
   description?: ApiEventDetail;
@@ -99,6 +149,7 @@ export interface ApiEventSet {
   dateTimes?: string[];
 }
 
+// from api/v1/events (get)
 export interface ApiEventReturned {
   id?: number;
   createdAt?: string;
@@ -108,6 +159,7 @@ export interface ApiEventReturned {
   Device?: { devicename: string };
 }
 
+// from api/v1/events/powerevents (get)
 export interface ApiPowerEventReturned {
   hasStopped: boolean;
   lastStarted?: string;
@@ -125,18 +177,21 @@ export interface ApiPowerEventReturned {
   };
 }
 
+// from api/v1/events/errors (get)
 export interface ApiEventErrorSimilar {
   device: string;
   timestamp: string;
   lines: string[];
 }
 
+// from api/v1/events/errors (get)
 export interface ApiEventErrorPattern {
   score?: number;
   index?: number;
   patterns?: string[];
 }
 
+// from api/v1/events/errors (get)
 export interface ApiEventError {
   devices: string[];
   timestamps: string[];
@@ -144,11 +199,91 @@ export interface ApiEventError {
   patterns: ApiEventErrorPattern[];
 }
 
+// from api/v1/events/errors (get)
 export interface ApiEventErrorCategory {
   name: string;
   devices: string[];
   errors: ApiEventError[];
 }
+
+/*******************************************************************
+* GROUP definitions
+********************************************************************/
+
+// from api/v1/groups (get)
+export interface ApiGroupReturned {
+  id: number;
+  groupname: string;
+  Users: ApiGroupUserRelation[];
+  Devices: ApiDeviceIdAndName[];
+  GroupUsers: ApiGroupUser[];
+}
+
+// from api/v1/groups/get
+export interface ApiGroupUserRelation {
+  id: number;
+  username: string;
+  GroupUsers: {
+	  admin: boolean,
+	  createdAt: string,
+	  updatedAt: string,
+	  GroupId: number,
+	  UserId: number
+  }
+}
+
+/*******************************************************************
+* RECORDING definitions
+********************************************************************/
+
+
+export interface ApiThermalRecordingInfo {
+  processingState?: string;
+  time?: Date | string;
+  duration?: number;
+  model?: string;
+  tracks?: ApiTrackInfo[];
+  noTracks?: boolean; // by default there will normally be one track, set to true if you don't want tracks
+  minsLater?: number; // minutes that later that the recording is taken
+  secsLater?: number; // minutes that later that the recording is taken
+  tags?: string[]; // short cut for defining tags for each track
+  lat?: number; // Latitude position for the recording
+  lng?: number; // Longitude position for the recording
+}
+
+export interface ApiTrackInfo {
+  start_s?: number;
+  end_s?: number;
+  tag?: string;
+  // confidence?: number,
+}
+
+// from api/v1/groups/<>/stations (post)
+export interface ApiStationData {
+  name: string;
+  lat: number;
+  lng: number;
+}
+
+// from api/v1/groups/<>/stations (get)
+export interface ApiStationDataReturned {
+  id: number;
+  name: string;
+  location: { 
+    type: string,
+    coordinates: [number, number];
+  },
+  lastUpdatedById: number;
+  createdAt: string;
+  retiredAt: string;
+  updatedAt: string;
+  GroupId: number;
+}
+
+
+/*******************************************************************
+* Custom structures used internally in test code
+********************************************************************/
 
 export interface TestComparableEvent {
   id: number;
@@ -189,30 +324,13 @@ export interface TestVisitsWhere {
   DeviceId?: number;
 }
 
-// Station data as supplied to API on creation.
-export interface ApiCreateStationData {
-  name: string;
-  lat: number;
-  lng: number;
+export interface TestComparablePowerEvent {
+  hasStopped: boolean;
+  hasAlerted: boolean;
 }
 
-export interface ApiTrackInfo {
-  start_s?: number;
-  end_s?: number;
-  tag?: string;
-  // confidence?: number,
+export interface TestDeviceAndGroup {
+  devicename: string;
+  groupname: string;
 }
 
-export interface ApiThermalRecordingInfo {
-  processingState?: string;
-  time?: Date | string;
-  duration?: number;
-  model?: string;
-  tracks?: ApiTrackInfo[];
-  noTracks?: boolean; // by default there will normally be one track, set to true if you don't want tracks
-  minsLater?: number; // minutes that later that the recording is taken
-  secsLater?: number; // minutes that later that the recording is taken
-  tags?: string[]; // short cut for defining tags for each track
-  lat?: number; // Latitude position for the recording
-  lng?: number; // Longitude position for the recording
-}

--- a/integration-tests/cypress/integration/api/alerts/device_alerts.ts
+++ b/integration-tests/cypress/integration/api/alerts/device_alerts.ts
@@ -364,7 +364,7 @@ describe("Devices alerts", () => {
     );
 
     //add userb to camera's group
-    cy.apiAddUserToGroup(usera.name, userb.name, usera.group, false, true);
+    cy.apiGroupUserAdd(usera.name, userb.name, usera.group, false, true);
 
     //upload a recording tagged as possum using device
     cy.uploadRecordingOnBehalfUsingDevice(
@@ -423,7 +423,7 @@ describe("Devices alerts", () => {
     );
 
     //add userb to camera's group
-    cy.apiAddUserToGroup(usera.name, userb.name, usera.group, false, true);
+    cy.apiGroupUserAdd(usera.name, userb.name, usera.group, false, true);
 
     //upload a recording tagged as possum using group
     cy.uploadRecordingOnBehalfUsingGroup(

--- a/integration-tests/cypress/integration/api/alerts/device_alerts.ts
+++ b/integration-tests/cypress/integration/api/alerts/device_alerts.ts
@@ -101,7 +101,7 @@ describe("Devices alerts", () => {
     );
 
     //upload a recording tagged as possum and  build an expected event using the returned recording details
-    cy.testRecordingAddWithTestData(
+    cy.testUploadRecording(
       usera.camera,
       { processingState: "FINISHED", tags: ["possum"] },
       null,
@@ -148,7 +148,7 @@ describe("Devices alerts", () => {
     );
 
     //upload a recording tagged as rat and  build an expected event using the returned recording details
-    cy.testRecordingAddWithTestData(
+    cy.testUploadRecording(
       usera.camera,
       { processingState: "FINISHED", tags: ["rat"] },
       null,
@@ -189,7 +189,7 @@ describe("Devices alerts", () => {
     );
 
     //upload a recording tagged as possum against another camera and  build an expected event using the returned recording details
-    cy.testRecordingAddWithTestData(
+    cy.testUploadRecording(
       camera2,
       { processingState: "FINISHED", tags: ["possum"] },
       null,
@@ -229,7 +229,7 @@ describe("Devices alerts", () => {
     );
 
     //upload a recording tagged as possum and  build an expected event using the returned recording details
-    cy.testRecordingAddWithTestData(
+    cy.testUploadRecording(
       usera.camera,
       {
         processingState: "FINISHED",
@@ -279,7 +279,7 @@ describe("Devices alerts", () => {
     );
 
     //upload a recording tagged as possum and  build an expected event using the returned recording details
-    cy.testRecordingAddWithTestData(
+    cy.testUploadRecording(
       usera.camera,
       {
         processingState: "FINISHED",
@@ -332,7 +332,7 @@ describe("Devices alerts", () => {
     );
 
     //upload a recording tagged as possum
-    cy.testRecordingAddWithTestData(
+    cy.testUploadRecording(
       usera.camera,
       { model: "different", processingState: "FINISHED", tags: ["possum"] },
       null,
@@ -557,7 +557,7 @@ describe("Devices alerts", () => {
     );
 
     //upload a 3rd recording tagged as possum and  build an expected event using the returned recording details
-    cy.testRecordingAddWithTestData(
+    cy.testUploadRecording(
       usera.camera,
       { processingState: "FINISHED", tags: ["possum"] },
       null,

--- a/integration-tests/cypress/integration/api/alerts/device_alerts.ts
+++ b/integration-tests/cypress/integration/api/alerts/device_alerts.ts
@@ -18,8 +18,8 @@ describe("Devices alerts", () => {
     const usera = getNewIdentity("alice");
     const userb = getNewIdentity("bob");
 
-    cy.apiCreateUser(userb.name);
-    cy.apiCreateUserGroupAndDevice(usera.name, usera.group, usera.camera);
+    cy.apiUserAdd(userb.name);
+    cy.testCreateUserGroupAndDevice(usera.name, usera.group, usera.camera);
 
     //attempt to create alert for camera that is not ours
     cy.apiAlertAdd(
@@ -39,7 +39,7 @@ describe("Devices alerts", () => {
       { bad_tag: "any", automatic: true },
     ] as unknown as ApiAlertConditions[];
     const usera = getNewIdentity("anna");
-    cy.apiCreateUserGroupAndDevice(usera.name, usera.group, usera.camera);
+    cy.testCreateUserGroupAndDevice(usera.name, usera.group, usera.camera);
 
     //attempt to create alert with invalid data
     cy.apiAlertAdd(
@@ -56,7 +56,7 @@ describe("Devices alerts", () => {
 
   it("Can create alert and has no events by default", () => {
     const usera = getNewIdentity("alfred");
-    cy.apiCreateUserGroupAndDevice(usera.name, usera.group, usera.camera);
+    cy.testCreateUserGroupAndDevice(usera.name, usera.group, usera.camera);
 
     // create alert
     cy.apiAlertAdd(
@@ -83,12 +83,12 @@ describe("Devices alerts", () => {
     cy.apiAlertCheck(usera.name, usera.camera, "emptyExpectedAlert");
 
     //check we have no events
-    cy.apiEventsCheckAgainstExpected(usera.name, usera.camera, null, 0);
+    cy.testEventsCheckAgainstExpected(usera.name, usera.camera, null, 0);
   });
 
   it("Can receive an alert", () => {
     const usera = getNewIdentity("andrew");
-    cy.apiCreateUserGroupAndDevice(usera.name, usera.group, usera.camera);
+    cy.testCreateUserGroupAndDevice(usera.name, usera.group, usera.camera);
 
     // create alert
     cy.apiAlertAdd(
@@ -130,12 +130,12 @@ describe("Devices alerts", () => {
     cy.apiAlertCheck(usera.name, usera.camera, "expectedAlert1");
 
     //check expected event is received
-    cy.apiEventsCheckAgainstExpected(usera.name, usera.camera, "event1");
+    cy.testEventsCheckAgainstExpected(usera.name, usera.camera, "event1");
   });
 
   it("No possum alert is sent for a rat", () => {
     const usera = getNewIdentity("alfreda");
-    cy.apiCreateUserGroupAndDevice(usera.name, usera.group, usera.camera);
+    cy.testCreateUserGroupAndDevice(usera.name, usera.group, usera.camera);
 
     // create alert
     cy.apiAlertAdd(
@@ -169,14 +169,14 @@ describe("Devices alerts", () => {
     cy.apiAlertCheck(usera.name, usera.camera, "emptyAlert");
 
     //check we have no events
-    cy.apiEventsCheckAgainstExpected(usera.name, usera.camera, null, 0);
+    cy.testEventsCheckAgainstExpected(usera.name, usera.camera, null, 0);
   });
 
   it("No possum alert is sent for a possum on a different device", () => {
     const usera = getNewIdentity("aine");
     const camera2 = "camera2";
-    cy.apiCreateUserGroupAndDevice(usera.name, usera.group, usera.camera);
-    cy.apiCreateDevice(camera2, usera.group);
+    cy.testCreateUserGroupAndDevice(usera.name, usera.group, usera.camera);
+    cy.apiDeviceAdd(camera2, usera.group);
 
     // create alert
     cy.apiAlertAdd(
@@ -210,13 +210,13 @@ describe("Devices alerts", () => {
     cy.apiAlertCheck(usera.name, usera.camera, "emptyAlert");
 
     //check we have no events against either camera
-    cy.apiEventsCheckAgainstExpected(usera.name, usera.camera, null, 0);
-    cy.apiEventsCheckAgainstExpected(usera.name, camera2, null, 0);
+    cy.testEventsCheckAgainstExpected(usera.name, usera.camera, null, 0);
+    cy.testEventsCheckAgainstExpected(usera.name, camera2, null, 0);
   });
 
   it("Recording with multiple tags - majority tag alerts", () => {
     const usera = getNewIdentity("aaron");
-    cy.apiCreateUserGroupAndDevice(usera.name, usera.group, usera.camera);
+    cy.testCreateUserGroupAndDevice(usera.name, usera.group, usera.camera);
 
     // create alert
     cy.apiAlertAdd(
@@ -261,12 +261,12 @@ describe("Devices alerts", () => {
     cy.apiAlertCheck(usera.name, usera.camera, "expectedAlert1d");
 
     //check expected event is received
-    cy.apiEventsCheckAgainstExpected(usera.name, usera.camera, "event1d");
+    cy.testEventsCheckAgainstExpected(usera.name, usera.camera, "event1d");
   });
 
   it("Recording with multiple tags - minority tag does not alert", () => {
     const usera = getNewIdentity("aaron");
-    cy.apiCreateUserGroupAndDevice(usera.name, usera.group, usera.camera);
+    cy.testCreateUserGroupAndDevice(usera.name, usera.group, usera.camera);
 
     // create alert
     cy.apiAlertAdd(
@@ -303,12 +303,12 @@ describe("Devices alerts", () => {
     cy.apiAlertCheck(usera.name, usera.camera, "expectedAlert1d");
 
     //check we have no events against camera
-    cy.apiEventsCheckAgainstExpected(usera.name, usera.camera, null, 0);
+    cy.testEventsCheckAgainstExpected(usera.name, usera.camera, null, 0);
   });
 
   it("Does not alert on non-master tags", () => {
     const usera = getNewIdentity("alistair");
-    cy.apiCreateUserGroupAndDevice(usera.name, usera.group, usera.camera);
+    cy.testCreateUserGroupAndDevice(usera.name, usera.group, usera.camera);
 
     // create alert
     cy.apiAlertAdd(
@@ -343,15 +343,15 @@ describe("Devices alerts", () => {
     cy.apiAlertCheck(usera.name, usera.camera, "emptyAlert");
 
     //check we have no events
-    cy.apiEventsCheckAgainstExpected(usera.name, usera.camera, null, 0);
+    cy.testEventsCheckAgainstExpected(usera.name, usera.camera, null, 0);
   });
 
   it("Alerts for recording uploaded on behalf using deviceId", () => {
     const usera = getNewIdentity("albert");
     const userb = getNewIdentity("barbera");
 
-    cy.apiCreateUser(userb.name);
-    cy.apiCreateUserGroupAndDevice(usera.name, usera.group, usera.camera);
+    cy.apiUserAdd(userb.name);
+    cy.testCreateUserGroupAndDevice(usera.name, usera.group, usera.camera);
 
     // create alert
     cy.apiAlertAdd(
@@ -397,7 +397,7 @@ describe("Devices alerts", () => {
     cy.apiAlertCheck(usera.name, usera.camera, "expectedAlert3");
 
     //check we have one event
-    cy.apiEventsCheckAgainstExpected(
+    cy.testEventsCheckAgainstExpected(
       usera.name,
       usera.camera,
       "expectedEvent3",
@@ -409,8 +409,8 @@ describe("Devices alerts", () => {
     const usera = getNewIdentity("andrea");
     const userb = getNewIdentity("bruce");
 
-    cy.apiCreateUser(userb.name);
-    cy.apiCreateUserGroupAndDevice(usera.name, usera.group, usera.camera);
+    cy.apiUserAdd(userb.name);
+    cy.testCreateUserGroupAndDevice(usera.name, usera.group, usera.camera);
 
     // create alert
     cy.apiAlertAdd(
@@ -457,7 +457,7 @@ describe("Devices alerts", () => {
     cy.apiAlertCheck(usera.name, usera.camera, "expectedAlert4");
 
     //check we have new event
-    cy.apiEventsCheckAgainstExpected(
+    cy.testEventsCheckAgainstExpected(
       usera.name,
       usera.camera,
       "expectedEvent4",
@@ -467,7 +467,7 @@ describe("Devices alerts", () => {
 
   it("Can generate and report multiple events", () => {
     const usera = getNewIdentity("aida");
-    cy.apiCreateUserGroupAndDevice(usera.name, usera.group, usera.camera);
+    cy.testCreateUserGroupAndDevice(usera.name, usera.group, usera.camera);
 
     // create alert
     cy.apiAlertAdd(
@@ -511,7 +511,7 @@ describe("Devices alerts", () => {
     cy.apiAlertCheck(usera.name, usera.camera, "expectedAlert1");
 
     //check there is now 1 event and that expected event has been received
-    cy.apiEventsCheckAgainstExpected(
+    cy.testEventsCheckAgainstExpected(
       usera.name,
       usera.camera,
       "expectedEvent1",
@@ -549,7 +549,7 @@ describe("Devices alerts", () => {
     cy.apiAlertCheck(usera.name, usera.camera, "expectedAlert2");
 
     //check there are now 2 events and 2nd expected event has been received
-    cy.apiEventsCheckAgainstExpected(
+    cy.testEventsCheckAgainstExpected(
       usera.name,
       usera.camera,
       "expectedEvent2",
@@ -586,7 +586,7 @@ describe("Devices alerts", () => {
     cy.apiAlertCheck(usera.name, usera.camera, "expectedAlert3");
 
     //check there are 3 events and 3rd expected event has been received
-    cy.apiEventsCheckAgainstExpected(
+    cy.testEventsCheckAgainstExpected(
       usera.name,
       usera.camera,
       "expectedEvent3",

--- a/integration-tests/cypress/integration/api/alerts/device_alerts.ts
+++ b/integration-tests/cypress/integration/api/alerts/device_alerts.ts
@@ -101,7 +101,7 @@ describe("Devices alerts", () => {
     );
 
     //upload a recording tagged as possum and  build an expected event using the returned recording details
-    cy.uploadRecording(
+    cy.testRecordingAddWithTestData(
       usera.camera,
       { processingState: "FINISHED", tags: ["possum"] },
       null,
@@ -148,7 +148,7 @@ describe("Devices alerts", () => {
     );
 
     //upload a recording tagged as rat and  build an expected event using the returned recording details
-    cy.uploadRecording(
+    cy.testRecordingAddWithTestData(
       usera.camera,
       { processingState: "FINISHED", tags: ["rat"] },
       null,
@@ -189,7 +189,7 @@ describe("Devices alerts", () => {
     );
 
     //upload a recording tagged as possum against another camera and  build an expected event using the returned recording details
-    cy.uploadRecording(
+    cy.testRecordingAddWithTestData(
       camera2,
       { processingState: "FINISHED", tags: ["possum"] },
       null,
@@ -229,7 +229,7 @@ describe("Devices alerts", () => {
     );
 
     //upload a recording tagged as possum and  build an expected event using the returned recording details
-    cy.uploadRecording(
+    cy.testRecordingAddWithTestData(
       usera.camera,
       {
         processingState: "FINISHED",
@@ -279,7 +279,7 @@ describe("Devices alerts", () => {
     );
 
     //upload a recording tagged as possum and  build an expected event using the returned recording details
-    cy.uploadRecording(
+    cy.testRecordingAddWithTestData(
       usera.camera,
       {
         processingState: "FINISHED",
@@ -332,7 +332,7 @@ describe("Devices alerts", () => {
     );
 
     //upload a recording tagged as possum
-    cy.uploadRecording(
+    cy.testRecordingAddWithTestData(
       usera.camera,
       { model: "different", processingState: "FINISHED", tags: ["possum"] },
       null,
@@ -367,7 +367,7 @@ describe("Devices alerts", () => {
     cy.apiGroupUserAdd(usera.name, userb.name, usera.group, false, true);
 
     //upload a recording tagged as possum using device
-    cy.uploadRecordingOnBehalfUsingDevice(
+    cy.apiRecordingAddOnBehalfUsingDevice(
       usera.camera,
       userb.name,
       { processingState: "FINISHED", tags: ["possum"] },
@@ -426,7 +426,7 @@ describe("Devices alerts", () => {
     cy.apiGroupUserAdd(usera.name, userb.name, usera.group, false, true);
 
     //upload a recording tagged as possum using group
-    cy.uploadRecordingOnBehalfUsingGroup(
+    cy.apiRecordingAddOnBehalfUsingGroup(
       usera.camera,
       usera.group,
       userb.name,
@@ -480,7 +480,7 @@ describe("Devices alerts", () => {
     );
 
     //upload a recording tagged as possum using group
-    cy.uploadRecordingOnBehalfUsingGroup(
+    cy.apiRecordingAddOnBehalfUsingGroup(
       usera.camera,
       usera.group,
       usera.name,
@@ -519,7 +519,7 @@ describe("Devices alerts", () => {
     );
 
     //upload a 2nd recording tagged as possum using device
-    cy.uploadRecordingOnBehalfUsingDevice(
+    cy.apiRecordingAddOnBehalfUsingDevice(
       usera.camera,
       usera.name,
       { processingState: "FINISHED", tags: ["possum"] },
@@ -557,7 +557,7 @@ describe("Devices alerts", () => {
     );
 
     //upload a 3rd recording tagged as possum and  build an expected event using the returned recording details
-    cy.uploadRecording(
+    cy.testRecordingAddWithTestData(
       usera.camera,
       { processingState: "FINISHED", tags: ["possum"] },
       null,

--- a/integration-tests/cypress/integration/api/alerts/device_stopped.ts
+++ b/integration-tests/cypress/integration/api/alerts/device_stopped.ts
@@ -6,14 +6,14 @@ describe("Devices stopped alerts", () => {
   const group = "stoppers";
   const user = "Jerry";
   before(() => {
-    cy.apiCreateUserGroup(user, group);
+    cy.testCreateUserAndGroup(user, group);
   });
 
   it("New Device isn't marked as stopped", () => {
     const camera = "Active";
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     cy.apiEventsAdd(camera, { type: EventTypes.POWERED_ON });
-    cy.apiPowerEventsCheckAgainstExpected(user, camera, {
+    cy.testPowerEventsCheckAgainstExpected(user, camera, {
       hasStopped: false,
       hasAlerted: false,
     });
@@ -22,11 +22,11 @@ describe("Devices stopped alerts", () => {
   it("Device that has been on for longer than 12 hours and hasn't stopped is marked as stopped", () => {
     const camera = "c1";
     const over12Hrs = moment().subtract(13, "hours");
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     cy.apiEventsAdd(camera, { type: EventTypes.POWERED_ON, details: {} }, [
       over12Hrs.toISOString(),
     ]);
-    cy.apiPowerEventsCheckAgainstExpected(user, camera, {
+    cy.testPowerEventsCheckAgainstExpected(user, camera, {
       hasStopped: true,
       hasAlerted: false,
     });
@@ -34,7 +34,7 @@ describe("Devices stopped alerts", () => {
 
   it("Device started and stopped yesterday, and not today is marked as stopped", () => {
     const camera = "c2";
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     const yesterdayStart = moment().subtract(40, "hours");
     const yesterdayStop = yesterdayStart.clone().add(28, "hours");
     cy.apiEventsAdd(camera, { type: EventTypes.POWERED_ON, details: {} }, [
@@ -43,7 +43,7 @@ describe("Devices stopped alerts", () => {
     cy.apiEventsAdd(camera, { type: EventTypes.POWERED_OFF, details: {} }, [
       yesterdayStop.toISOString(),
     ]);
-    cy.apiPowerEventsCheckAgainstExpected(user, camera, {
+    cy.testPowerEventsCheckAgainstExpected(user, camera, {
       hasStopped: true,
       hasAlerted: false,
     });
@@ -51,12 +51,12 @@ describe("Devices stopped alerts", () => {
 
   it("Device started over 12 hours ago but never stopped is marked as stopped", () => {
     const camera = "c3";
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     const yesterday = moment().subtract(13, "hours");
     cy.apiEventsAdd(camera, { type: EventTypes.POWERED_ON, details: {} }, [
       yesterday.toISOString(),
     ]);
-    cy.apiPowerEventsCheckAgainstExpected(user, camera, {
+    cy.testPowerEventsCheckAgainstExpected(user, camera, {
       hasStopped: true,
       hasAlerted: false,
     });
@@ -64,17 +64,17 @@ describe("Devices stopped alerts", () => {
 
   it("Once reported is not marked as stopped again, until powered on again", () => {
     const camera = "c4";
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     const yesterday = moment().subtract(13, "hours");
     cy.apiEventsAdd(camera, { type: EventTypes.POWERED_ON, details: {} }, [
       yesterday.toISOString(),
     ]);
-    cy.apiPowerEventsCheckAgainstExpected(user, camera, {
+    cy.testPowerEventsCheckAgainstExpected(user, camera, {
       hasStopped: true,
       hasAlerted: false,
     });
     cy.apiEventsAdd(camera, { type: EventTypes.STOP_REPORTED });
-    cy.apiPowerEventsCheckAgainstExpected(user, camera, {
+    cy.testPowerEventsCheckAgainstExpected(user, camera, {
       hasStopped: true,
       hasAlerted: true,
     });
@@ -82,7 +82,7 @@ describe("Devices stopped alerts", () => {
 
   it("Device powered on & off yesterday but only on last night is marked as stopped", () => {
     const camera = "c5";
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     const priorOn = moment().subtract(37, "hours");
     const priorStop = priorOn.clone().add(12, "hours");
     const lastStart = priorOn.clone().add(24, "hours");
@@ -96,7 +96,7 @@ describe("Devices stopped alerts", () => {
     cy.apiEventsAdd(camera, { type: EventTypes.POWERED_ON, details: {} }, [
       lastStart.toISOString(),
     ]);
-    cy.apiPowerEventsCheckAgainstExpected(user, camera, {
+    cy.testPowerEventsCheckAgainstExpected(user, camera, {
       hasStopped: true,
       hasAlerted: false,
     });
@@ -104,7 +104,7 @@ describe("Devices stopped alerts", () => {
 
   it("Device checked before it is expected to have powered down is not marked as stopped", () => {
     const camera = "c6";
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     const priorOn = moment().subtract(36, "hours");
     const priorStop = moment().subtract(24, "hours");
     const lastStart = priorOn.clone().add(24, "hours");
@@ -118,7 +118,7 @@ describe("Devices stopped alerts", () => {
     cy.apiEventsAdd(camera, { type: EventTypes.POWERED_ON, details: {} }, [
       lastStart.toISOString(),
     ]);
-    cy.apiPowerEventsCheckAgainstExpected(user, camera, {
+    cy.testPowerEventsCheckAgainstExpected(user, camera, {
       hasStopped: false,
       hasAlerted: false,
     });
@@ -126,7 +126,7 @@ describe("Devices stopped alerts", () => {
 
   it("Device hasn't been checked for a long time is marked as stopped", () => {
     const camera = "c7";
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     const priorOn = moment().subtract(20, "days");
     const priorStop = moment().subtract(20, "days").add(12, "hours");
     cy.apiEventsAdd(camera, { type: EventTypes.POWERED_ON, details: {} }, [
@@ -135,7 +135,7 @@ describe("Devices stopped alerts", () => {
     cy.apiEventsAdd(camera, { type: EventTypes.POWERED_OFF, details: {} }, [
       priorStop.toISOString(),
     ]);
-    cy.apiPowerEventsCheckAgainstExpected(user, camera, {
+    cy.testPowerEventsCheckAgainstExpected(user, camera, {
       hasStopped: true,
       hasAlerted: false,
     });
@@ -143,7 +143,7 @@ describe("Devices stopped alerts", () => {
 
   it("Device that has been reported, is marked as stopped again after new power cycles", () => {
     const camera = "c8";
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     const priorOn = moment().subtract(5, "days");
     const priorStop = moment().subtract(5, "days").add(12, "hours");
     cy.apiEventsAdd(camera, { type: EventTypes.POWERED_ON, details: {} }, [
@@ -152,14 +152,14 @@ describe("Devices stopped alerts", () => {
     cy.apiEventsAdd(camera, { type: EventTypes.POWERED_OFF, details: {} }, [
       priorStop.toISOString(),
     ]);
-    cy.apiPowerEventsCheckAgainstExpected(user, camera, {
+    cy.testPowerEventsCheckAgainstExpected(user, camera, {
       hasStopped: true,
       hasAlerted: false,
     });
     cy.apiEventsAdd(camera, { type: EventTypes.STOP_REPORTED, details: {} }, [
       priorStop.toISOString(),
     ]);
-    cy.apiPowerEventsCheckAgainstExpected(user, camera, {
+    cy.testPowerEventsCheckAgainstExpected(user, camera, {
       hasStopped: true,
       hasAlerted: true,
     });
@@ -172,7 +172,7 @@ describe("Devices stopped alerts", () => {
     cy.apiEventsAdd(camera, { type: EventTypes.POWERED_OFF, details: {} }, [
       newOff.toISOString(),
     ]);
-    cy.apiPowerEventsCheckAgainstExpected(user, camera, {
+    cy.testPowerEventsCheckAgainstExpected(user, camera, {
       hasStopped: true,
       hasAlerted: false,
     });

--- a/integration-tests/cypress/integration/api/authenticate/authenticate.ts
+++ b/integration-tests/cypress/integration/api/authenticate/authenticate.ts
@@ -116,9 +116,9 @@ describe("Authentication", () => {
       //admin_test authenticates as Bruce
       cy.apiAuthenticateAs("admin_test", userB);
       //verify each user gets their own data
-      cy.apiCheckUserCanSeeGroup(userB + "_on_behalf", group2);
+      cy.apiGroupUserCheckAccess(userB + "_on_behalf", group2);
       //vefiry user cannot see items outside their group (i.e. are not super_user)
-      cy.apiCheckUserCanSeeGroup(userB + "_on_behalf", group1, false);
+      cy.apiGroupUserCheckAccess(userB + "_on_behalf", group1, false);
     });
   } else {
     it.skip("Superuser can authenticate as another user and receive their permissions", () => {});

--- a/integration-tests/cypress/integration/api/authenticate/authenticate.ts
+++ b/integration-tests/cypress/integration/api/authenticate/authenticate.ts
@@ -16,8 +16,8 @@ describe("Authentication", () => {
   const camera2 = "second_camera";
 
   before(() => {
-    cy.apiCreateUserGroupAndDevice(userA, group1, camera1);
-    cy.apiCreateUserGroupAndDevice(userB, group2, camera2);
+    cy.testCreateUserGroupAndDevice(userA, group1, camera1);
+    cy.testCreateUserGroupAndDevice(userB, group2, camera2);
   });
 
   it("Can authenticate as a device", () => {
@@ -116,9 +116,9 @@ describe("Authentication", () => {
       //admin_test authenticates as Bruce
       cy.apiAuthenticateAs("admin_test", userB);
       //verify each user gets their own data
-      cy.apiGroupUserCheckAccess(userB + "_on_behalf", group2);
+      cy.testGroupUserCheckAccess(userB + "_on_behalf", group2);
       //vefiry user cannot see items outside their group (i.e. are not super_user)
-      cy.apiGroupUserCheckAccess(userB + "_on_behalf", group1, false);
+      cy.testGroupUserCheckAccess(userB + "_on_behalf", group1, false);
     });
   } else {
     it.skip("Superuser can authenticate as another user and receive their permissions", () => {});
@@ -140,7 +140,7 @@ describe("Authentication", () => {
     cy.apiToken(userA, null, { devices: "r" });
 
     //get device
-    cy.apiCheckDevicesQuery(
+    cy.apiDeviceQueryCheck(
       userA + "_temp_token",
       [{ devicename: getTestName(camera1), groupname: getTestName(group1) }],
       null,
@@ -152,7 +152,7 @@ describe("Authentication", () => {
     //TODO: enable the remainder of the checks once issue 57 is fixed, or remove the remaining checks if we do not implement.
 
     //get devices list
-    //cy.apiCheckDeviceInGroup(userA+"_temp_token",[{id: getCreds(camera1).id, devicename: getTestName(camera1), groupName: getTestName(group1), userIsAdmin: true, Users: []}]);
+    //cy.apiDeviceInGroupCheck(userA+"_temp_token",[{id: getCreds(camera1).id, devicename: getTestName(camera1), groupName: getTestName(group1), userIsAdmin: true, Users: []}]);
 
     //get device users
 
@@ -160,7 +160,7 @@ describe("Authentication", () => {
     //cy.uploadRecordingOnBehalfUsingDevice(camera1, userA, { tags: ["possum"]}, null, 'recording1');
 
     //retrieve recording for device
-    //cy.apiCheckDeviceHasRecordings(userA+'_temp_token',camera1,1);
+    //cy.testCheckDeviceHasRecordings(userA+'_temp_token',camera1,1);
 
     //vefiry user cannot see items outside their group (i.e. are not super_user)
     //cy.apiCheckDevice(userA+"_temp_token",camera1,group1,{},HTTP_AuthorizationError);

--- a/integration-tests/cypress/integration/api/authenticate/authenticate.ts
+++ b/integration-tests/cypress/integration/api/authenticate/authenticate.ts
@@ -157,7 +157,7 @@ describe("Authentication", () => {
     //get device users
 
     //upload a recording for device (using user's main token)
-    //cy.uploadRecordingOnBehalfUsingDevice(camera1, userA, { tags: ["possum"]}, null, 'recording1');
+    //cy.apiRecordingAddOnBehalfUsingDevice(camera1, userA, { tags: ["possum"]}, null, 'recording1');
 
     //retrieve recording for device
     //cy.testCheckDeviceHasRecordings(userA+'_temp_token',camera1,1);

--- a/integration-tests/cypress/integration/api/devices/device_in_group.ts
+++ b/integration-tests/cypress/integration/api/devices/device_in_group.ts
@@ -23,11 +23,11 @@ describe("Device in group", () => {
   let expectedDeviceInGroupUserView: ApiDeviceInGroupDevice;
 
   before(() => {
-    cy.apiCreateUser(groupMember);
-    cy.apiCreateUser(deviceMember);
-    cy.apiCreateUser(deviceAdmin);
-    cy.apiCreateUser(hacker);
-    cy.apiCreateUserGroupAndDevice(groupAdmin, group, camera).then(() => {
+    cy.apiUserAdd(groupMember);
+    cy.apiUserAdd(deviceMember);
+    cy.apiUserAdd(deviceAdmin);
+    cy.apiUserAdd(hacker);
+    cy.testCreateUserGroupAndDevice(groupAdmin, group, camera).then(() => {
       expectedDeviceInGroupAdminView = {
         id: getCreds(camera).id,
         devicename: getTestName(camera),
@@ -54,13 +54,13 @@ describe("Device in group", () => {
         users: null,
       };
     });
-    cy.apiAddUserToDevice(groupAdmin, deviceMember, camera);
-    cy.apiAddUserToDevice(groupAdmin, deviceAdmin, camera, ADMIN);
+    cy.apiDeviceUserAdd(groupAdmin, deviceMember, camera);
+    cy.apiDeviceUserAdd(groupAdmin, deviceAdmin, camera, ADMIN);
     cy.apiGroupUserAdd(groupAdmin, groupMember, group, NOT_ADMIN);
   });
 
   it("Group admin should see everything including device users", () => {
-    cy.apiCheckDeviceInGroup(
+    cy.apiDeviceInGroupCheck(
       groupAdmin,
       camera,
       group,
@@ -70,7 +70,7 @@ describe("Device in group", () => {
   });
 
   it("Device admin should see everything including device users", () => {
-    cy.apiCheckDeviceInGroup(
+    cy.apiDeviceInGroupCheck(
       deviceAdmin,
       camera,
       group,
@@ -80,7 +80,7 @@ describe("Device in group", () => {
   });
 
   it("Group member should be able to read all but device users", () => {
-    cy.apiCheckDeviceInGroup(
+    cy.apiDeviceInGroupCheck(
       groupMember,
       camera,
       group,
@@ -90,7 +90,7 @@ describe("Device in group", () => {
   });
 
   it("Device member should be able to read all but device users", () => {
-    cy.apiCheckDeviceInGroup(
+    cy.apiDeviceInGroupCheck(
       deviceMember,
       camera,
       group,
@@ -104,7 +104,7 @@ describe("Device in group", () => {
       `Check that ${hacker} is blocked from getting device`,
       {}
     );
-    cy.apiCheckDeviceInGroup(
+    cy.apiDeviceInGroupCheck(
       hacker,
       camera,
       group,
@@ -116,7 +116,7 @@ describe("Device in group", () => {
   });
 
   it("Can retrieve group by id instead of name", () => {
-    cy.apiCheckDeviceInGroup(
+    cy.apiDeviceInGroupCheck(
       deviceMember,
       camera,
       group,
@@ -127,7 +127,7 @@ describe("Device in group", () => {
 
   // TODO: Fails - returns empty response instead of error message. Issue 60
   it.skip("Correctly handles invalid device", () => {
-    cy.apiCheckDeviceInGroup(
+    cy.apiDeviceInGroupCheck(
       groupAdmin,
       "bad-camera",
       group,
@@ -139,7 +139,7 @@ describe("Device in group", () => {
   });
 
   it("Correctly handles invalid group", () => {
-    cy.apiCheckDeviceInGroup(
+    cy.apiDeviceInGroupCheck(
       groupAdmin,
       camera,
       "bad-group",

--- a/integration-tests/cypress/integration/api/devices/device_in_group.ts
+++ b/integration-tests/cypress/integration/api/devices/device_in_group.ts
@@ -56,7 +56,7 @@ describe("Device in group", () => {
     });
     cy.apiAddUserToDevice(groupAdmin, deviceMember, camera);
     cy.apiAddUserToDevice(groupAdmin, deviceAdmin, camera, ADMIN);
-    cy.apiAddUserToGroup(groupAdmin, groupMember, group, NOT_ADMIN);
+    cy.apiGroupUserAdd(groupAdmin, groupMember, group, NOT_ADMIN);
   });
 
   it("Group admin should see everything including device users", () => {

--- a/integration-tests/cypress/integration/api/devices/device_query.ts
+++ b/integration-tests/cypress/integration/api/devices/device_query.ts
@@ -50,7 +50,7 @@ describe("Devices/query", () => {
       groupname: getTestName(group1),
     };
 
-    cy.apiAddUserToGroup(groupAdmin, groupMember, group1, NOT_ADMIN);
+    cy.apiGroupUserAdd(groupAdmin, groupMember, group1, NOT_ADMIN);
     cy.apiAddUserToDevice(groupAdmin, deviceMember, cameraA1);
     cy.apiAddUserToDevice(groupAdmin, deviceAdmin, cameraA1, ADMIN);
 
@@ -63,8 +63,8 @@ describe("Devices/query", () => {
 
     //user who can see both groups
     cy.apiCreateUser(everythingUser);
-    cy.apiAddUserToGroup(groupAdmin, everythingUser, group1, NOT_ADMIN);
-    cy.apiAddUserToGroup(user2, everythingUser, group2, NOT_ADMIN);
+    cy.apiGroupUserAdd(groupAdmin, everythingUser, group1, NOT_ADMIN);
+    cy.apiGroupUserAdd(user2, everythingUser, group2, NOT_ADMIN);
 
     //reregistered device
     cy.apiCreateUserGroupAndDevice(user3, group3, camera3);

--- a/integration-tests/cypress/integration/api/devices/device_query.ts
+++ b/integration-tests/cypress/integration/api/devices/device_query.ts
@@ -35,40 +35,40 @@ describe("Devices/query", () => {
 
   before(() => {
     //first group, users & devices
-    cy.apiCreateUser(groupMember);
-    cy.apiCreateUser(deviceAdmin);
-    cy.apiCreateUser(deviceMember);
-    cy.apiCreateUser(hacker);
-    cy.apiCreateUserGroupAndDevice(groupAdmin, group1, cameraA1);
+    cy.apiUserAdd(groupMember);
+    cy.apiUserAdd(deviceAdmin);
+    cy.apiUserAdd(deviceMember);
+    cy.apiUserAdd(hacker);
+    cy.testCreateUserGroupAndDevice(groupAdmin, group1, cameraA1);
     expectedDeviceA1 = {
       devicename: getTestName(cameraA1),
       groupname: getTestName(group1),
     };
-    cy.apiCreateDevice(cameraB1, group1);
+    cy.apiDeviceAdd(cameraB1, group1);
     expectedDeviceB1 = {
       devicename: getTestName(cameraB1),
       groupname: getTestName(group1),
     };
 
     cy.apiGroupUserAdd(groupAdmin, groupMember, group1, NOT_ADMIN);
-    cy.apiAddUserToDevice(groupAdmin, deviceMember, cameraA1);
-    cy.apiAddUserToDevice(groupAdmin, deviceAdmin, cameraA1, ADMIN);
+    cy.apiDeviceUserAdd(groupAdmin, deviceMember, cameraA1);
+    cy.apiDeviceUserAdd(groupAdmin, deviceAdmin, cameraA1, ADMIN);
 
     //second group
-    cy.apiCreateUserGroupAndDevice(user2, group2, cameraA2);
+    cy.testCreateUserGroupAndDevice(user2, group2, cameraA2);
     expectedDeviceA2 = {
       devicename: getTestName(cameraA2),
       groupname: getTestName(group2),
     };
 
     //user who can see both groups
-    cy.apiCreateUser(everythingUser);
+    cy.apiUserAdd(everythingUser);
     cy.apiGroupUserAdd(groupAdmin, everythingUser, group1, NOT_ADMIN);
     cy.apiGroupUserAdd(user2, everythingUser, group2, NOT_ADMIN);
 
     //reregistered device
-    cy.apiCreateUserGroupAndDevice(user3, group3, camera3);
-    cy.apiAddUserToDevice(user3, user3, camera3);
+    cy.testCreateUserGroupAndDevice(user3, group3, camera3);
+    cy.apiDeviceUserAdd(user3, user3, camera3);
     expectedDevice3 = {
       devicename: getTestName(camera3),
       groupname: getTestName(group3),
@@ -81,13 +81,13 @@ describe("Devices/query", () => {
   });
 
   it("Can match a single device by group+devicename", () => {
-    cy.apiCheckDevicesQuery(groupAdmin, [expectedDeviceA1], null, [
+    cy.apiDeviceQueryCheck(groupAdmin, [expectedDeviceA1], null, [
       expectedDeviceA1,
     ]);
   });
 
   it("Can match a single device by group", () => {
-    cy.apiCheckDevicesQuery(
+    cy.apiDeviceQueryCheck(
       user2,
       null,
       [getTestName(group2)],
@@ -96,7 +96,7 @@ describe("Devices/query", () => {
   });
 
   it("Can match multiple devices by group+devicename", () => {
-    cy.apiCheckDevicesQuery(
+    cy.apiDeviceQueryCheck(
       groupAdmin,
       [expectedDeviceA1, expectedDeviceB1],
       null,
@@ -105,7 +105,7 @@ describe("Devices/query", () => {
   });
 
   it("Can match multiple devices in single group", () => {
-    cy.apiCheckDevicesQuery(
+    cy.apiDeviceQueryCheck(
       groupAdmin,
       null,
       [getTestName(group1)],
@@ -114,7 +114,7 @@ describe("Devices/query", () => {
   });
 
   it("Can match multiple devices in multiple groups", () => {
-    cy.apiCheckDevicesQuery(
+    cy.apiDeviceQueryCheck(
       everythingUser,
       null,
       [getTestName(group1), getTestName(group2)],
@@ -124,7 +124,7 @@ describe("Devices/query", () => {
 
   it("Can match on device AND group", () => {
     // return everything wher both queries fully match
-    cy.apiCheckDevicesQuery(
+    cy.apiDeviceQueryCheck(
       everythingUser,
       [expectedDeviceA1, expectedDeviceB1, expectedDeviceA2],
       [getTestName(group1), getTestName(group2)],
@@ -132,7 +132,7 @@ describe("Devices/query", () => {
       "and"
     );
     // return common elements where devices returns more than groups
-    cy.apiCheckDevicesQuery(
+    cy.apiDeviceQueryCheck(
       everythingUser,
       [expectedDeviceA1, expectedDeviceB1, expectedDeviceA2],
       [getTestName(group1)],
@@ -140,7 +140,7 @@ describe("Devices/query", () => {
       "and"
     );
     // return common elements where group returns more than devices
-    cy.apiCheckDevicesQuery(
+    cy.apiDeviceQueryCheck(
       everythingUser,
       [expectedDeviceA1, expectedDeviceA2],
       [getTestName(group1), getTestName(group2)],
@@ -148,7 +148,7 @@ describe("Devices/query", () => {
       "and"
     );
     // return nothing where no overlap of devices and groups
-    cy.apiCheckDevicesQuery(
+    cy.apiDeviceQueryCheck(
       everythingUser,
       [expectedDeviceA1, expectedDeviceB1],
       [getTestName(group2)],
@@ -162,7 +162,7 @@ describe("Devices/query", () => {
     it("Super-user should see any device", () => {
       cy.apiSignInAs(null, null, superuser, suPassword);
 
-      cy.apiCheckDevicesQuery(
+      cy.apiDeviceQueryCheck(
         superuser,
         null,
         [getTestName(group1), getTestName(group2)],
@@ -174,7 +174,7 @@ describe("Devices/query", () => {
   }
 
   it("Group admin can see all and only their group's devices", () => {
-    cy.apiCheckDevicesQuery(
+    cy.apiDeviceQueryCheck(
       groupAdmin,
       null,
       [getTestName(group1), getTestName(group2)],
@@ -183,7 +183,7 @@ describe("Devices/query", () => {
   });
 
   it("Group user can see all and only their group's devices", () => {
-    cy.apiCheckDevicesQuery(
+    cy.apiDeviceQueryCheck(
       groupMember,
       null,
       [getTestName(group1), getTestName(group2)],
@@ -192,7 +192,7 @@ describe("Devices/query", () => {
   });
 
   it("Device admin can see all and only their devices", () => {
-    cy.apiCheckDevicesQuery(
+    cy.apiDeviceQueryCheck(
       deviceAdmin,
       null,
       [getTestName(group1), getTestName(group2)],
@@ -201,7 +201,7 @@ describe("Devices/query", () => {
   });
 
   it("Device user can see all and only their devices", () => {
-    cy.apiCheckDevicesQuery(
+    cy.apiDeviceQueryCheck(
       deviceMember,
       null,
       [getTestName(group1), getTestName(group2)],
@@ -210,7 +210,7 @@ describe("Devices/query", () => {
   });
 
   it("Displays both active and inactive devices", () => {
-    cy.apiCheckDevicesQuery(
+    cy.apiDeviceQueryCheck(
       user3,
       null,
       [getTestName(group3)],
@@ -226,36 +226,36 @@ describe("Devices/query", () => {
     };
 
     //Test with Salt Id = device id by default
-    cy.apiCheckDevicesQuery(everythingUser, [expectedDeviceA1], null, [
+    cy.apiDeviceQueryCheck(everythingUser, [expectedDeviceA1], null, [
       expectedDevice,
     ]);
 
     //Test with Salt Id specified on register
-    cy.apiCreateDevice(camera5, group1, 9999);
+    cy.apiDeviceAdd(camera5, group1, 9999);
     const expectedDevice5 = {
       devicename: getTestName(camera5),
       groupname: getTestName(group1),
       saltId: 9999,
     };
-    cy.apiCheckDevicesQuery(everythingUser, [expectedDevice5], null, [
+    cy.apiDeviceQueryCheck(everythingUser, [expectedDevice5], null, [
       expectedDevice5,
     ]);
   });
 
   it("Correctly handles incorrect parameters", () => {
     //no group or devices (returns empty list)
-    cy.apiCheckDevicesQuery(groupMember, null, null, []);
+    cy.apiDeviceQueryCheck(groupMember, null, null, []);
 
     //devices is missing devicename
     //TODO: This fails with internal server error - issue 64.  Reenable when fixed.
-    //    cy.apiCheckDevicesQuery(groupMember, [{"groupname": getTestName(group1)}], null, [], 'or', HTTP_Unprocessable);
+    //    cy.apiDeviceQueryCheck(groupMember, [{"groupname": getTestName(group1)}], null, [], 'or', HTTP_Unprocessable);
 
     //devices is missing groupname
     //TODO: This fails with internal server error - issue 64.  Reenable when fixed.
-    //    cy.apiCheckDevicesQuery(groupMember, [{"devicename": getTestName(cameraA1)}], null, [], 'or', HTTP_Unprocessable);
+    //    cy.apiDeviceQueryCheck(groupMember, [{"devicename": getTestName(cameraA1)}], null, [], 'or', HTTP_Unprocessable);
 
     //devices not  JSON array
-    cy.apiCheckDevicesQuery(
+    cy.apiDeviceQueryCheck(
       groupMember,
       "bad value" as unknown as [],
       null,
@@ -265,7 +265,7 @@ describe("Devices/query", () => {
     );
 
     //group not  JSON array
-    cy.apiCheckDevicesQuery(
+    cy.apiDeviceQueryCheck(
       groupMember,
       null,
       "bad value" as unknown as [],
@@ -275,7 +275,7 @@ describe("Devices/query", () => {
     );
 
     //operator not and or or
-    cy.apiCheckDevicesQuery(
+    cy.apiDeviceQueryCheck(
       groupMember,
       null,
       [getTestName(group1)],

--- a/integration-tests/cypress/integration/api/devices/device_register.ts
+++ b/integration-tests/cypress/integration/api/devices/device_register.ts
@@ -17,7 +17,7 @@ describe("Device register", () => {
   before(() => {
     cy.apiCreateUserGroupAndDevice("Anita", camsGroup, "gotya");
     cy.apiCreateDevice("defaultcam", camsGroup);
-    cy.apiCreateGroup("Anita", otherCams, true);
+    cy.apiGroupAdd("Anita", otherCams, true);
   });
 
   it("group can have multiple devices with a different names", () => {

--- a/integration-tests/cypress/integration/api/devices/device_register.ts
+++ b/integration-tests/cypress/integration/api/devices/device_register.ts
@@ -15,21 +15,21 @@ describe("Device register", () => {
   const LOG = true;
 
   before(() => {
-    cy.apiCreateUserGroupAndDevice("Anita", camsGroup, "gotya");
-    cy.apiCreateDevice("defaultcam", camsGroup);
+    cy.testCreateUserGroupAndDevice("Anita", camsGroup, "gotya");
+    cy.apiDeviceAdd("defaultcam", camsGroup);
     cy.apiGroupAdd("Anita", otherCams, true);
   });
 
   it("group can have multiple devices with a different names", () => {
-    cy.apiCreateDevice("Smile", camsGroup);
+    cy.apiDeviceAdd("Smile", camsGroup);
   });
 
   it("devices in different groups can have the same names", () => {
-    cy.apiCreateDevice("gotya", otherCams);
+    cy.apiDeviceAdd("gotya", otherCams);
   });
 
   it("But cannot create device with same name (even with different case) in the same group", () => {
-    cy.apiCreateDevice(
+    cy.apiDeviceAdd(
       "GotYa",
       camsGroup,
       KEEP_SALT_ID,
@@ -41,7 +41,7 @@ describe("Device register", () => {
   });
 
   it("Should not be able to create a device name that doesn't have any letters", () => {
-    cy.apiCreateDevice(
+    cy.apiDeviceAdd(
       "12345",
       camsGroup,
       KEEP_SALT_ID,
@@ -50,7 +50,7 @@ describe("Device register", () => {
       LOG,
       HTTP_Unprocessable
     );
-    cy.apiCreateDevice(
+    cy.apiDeviceAdd(
       "123-34",
       camsGroup,
       KEEP_SALT_ID,
@@ -62,13 +62,13 @@ describe("Device register", () => {
   });
 
   it("Should be able to create a device name that has -, _, and spaces in it", () => {
-    cy.apiCreateDevice("funny device1", camsGroup);
-    cy.apiCreateDevice("funny-device2", camsGroup);
-    cy.apiCreateDevice("funny_device3", camsGroup);
+    cy.apiDeviceAdd("funny device1", camsGroup);
+    cy.apiDeviceAdd("funny-device2", camsGroup);
+    cy.apiDeviceAdd("funny_device3", camsGroup);
   });
 
   it("Shouldn't be able to create a device name that starts with -, _, and spaces in it", () => {
-    cy.apiCreateDevice(
+    cy.apiDeviceAdd(
       " device1",
       camsGroup,
       KEEP_SALT_ID,
@@ -77,7 +77,7 @@ describe("Device register", () => {
       LOG,
       HTTP_Unprocessable
     );
-    cy.apiCreateDevice(
+    cy.apiDeviceAdd(
       "-device2",
       camsGroup,
       KEEP_SALT_ID,
@@ -86,7 +86,7 @@ describe("Device register", () => {
       LOG,
       HTTP_Unprocessable
     );
-    cy.apiCreateDevice(
+    cy.apiDeviceAdd(
       "_device3",
       camsGroup,
       KEEP_SALT_ID,
@@ -105,22 +105,22 @@ describe("Device register", () => {
     };
 
     //Test with Salt Id = device id by default
-    cy.apiCheckDevicesQuery("Anita", [expectedDevice], null, [expectedDevice]);
+    cy.apiDeviceQueryCheck("Anita", [expectedDevice], null, [expectedDevice]);
   });
 
   it("Can register a device and specify salt id", () => {
-    cy.apiCreateDevice("specify salt", camsGroup, 9998);
+    cy.apiDeviceAdd("specify salt", camsGroup, 9998);
     const expectedDevice = {
       devicename: getTestName("specify salt"),
       groupname: getTestName(camsGroup),
       saltId: 9998,
     };
-    cy.apiCheckDevicesQuery("Anita", [expectedDevice], null, [expectedDevice]);
+    cy.apiDeviceQueryCheck("Anita", [expectedDevice], null, [expectedDevice]);
   });
 
   it("When registering a device must specify a valid password", () => {
     //not blank
-    cy.apiCreateDevice(
+    cy.apiDeviceAdd(
       "device4",
       camsGroup,
       KEEP_SALT_ID,
@@ -130,7 +130,7 @@ describe("Device register", () => {
       HTTP_Unprocessable
     );
     //not space
-    cy.apiCreateDevice(
+    cy.apiDeviceAdd(
       "device5",
       camsGroup,
       KEEP_SALT_ID,
@@ -140,7 +140,7 @@ describe("Device register", () => {
       HTTP_Unprocessable
     );
     //not less than 8 chars
-    cy.apiCreateDevice(
+    cy.apiDeviceAdd(
       "device6",
       camsGroup,
       KEEP_SALT_ID,
@@ -152,7 +152,7 @@ describe("Device register", () => {
   });
 
   it("When registering a device must specify a group that exists", () => {
-    cy.apiCreateDevice(
+    cy.apiDeviceAdd(
       "device4",
       "nonexitant group",
       KEEP_SALT_ID,
@@ -164,6 +164,6 @@ describe("Device register", () => {
   });
 
   it.skip("Correctly handles missing parameters in register device", () => {
-    //TODO: write this (helper apiCreateDevice does not yet support missing params)
+    //TODO: write this (helper apiDeviceAdd does not yet support missing params)
   });
 });

--- a/integration-tests/cypress/integration/api/devices/device_reregister.ts
+++ b/integration-tests/cypress/integration/api/devices/device_reregister.ts
@@ -14,7 +14,7 @@ describe("Device reregister", () => {
   const GENERATE_PASSWORD = null;
 
   before(() => {
-    cy.apiCreateUserGroupAndDevice(
+    cy.testCreateUserGroupAndDevice(
       "Augustus",
       "RR_default_group",
       "RR_default_camera"
@@ -27,8 +27,8 @@ describe("Device reregister", () => {
     let expectedDevice1b: ApiDevicesDevice;
 
     //register camera & store device details
-    cy.apiCreateUserGroup("RR_user1", "RR_group1");
-    cy.apiCreateDevice("RR_cam1", "RR_group1").then(() => {
+    cy.testCreateUserAndGroup("RR_user1", "RR_group1");
+    cy.apiDeviceAdd("RR_cam1", "RR_group1").then(() => {
       expectedDevice1 = {
         id: getCreds("RR_cam1").id,
         devicename: getTestName("RR_cam1"),
@@ -46,9 +46,9 @@ describe("Device reregister", () => {
         Users: [],
       };
       //verify old device is not present and new one is
-      cy.apiCheckDevices("RR_user1", [expectedDevice1b]);
+      cy.apiDevicesCheck("RR_user1", [expectedDevice1b]);
       //verify old device is listed as inactive
-      cy.apiCheckDevices("RR_user1", [expectedDevice1, expectedDevice1b], {
+      cy.apiDevicesCheck("RR_user1", [expectedDevice1, expectedDevice1b], {
         onlyActive: false,
       });
     });
@@ -59,7 +59,7 @@ describe("Device reregister", () => {
     let expectedDevice2b: ApiDevicesDevice;
 
     //register camera & store device details
-    cy.apiCreateUserGroupAndDevice("RR_user2", "RR_group2", "RR_cam2").then(
+    cy.testCreateUserGroupAndDevice("RR_user2", "RR_group2", "RR_cam2").then(
       () => {
         expectedDevice2 = {
           id: getCreds("RR_cam2").id,
@@ -71,7 +71,7 @@ describe("Device reregister", () => {
     );
 
     //second group
-    cy.apiCreateUserGroup("RR_user2b", "RR_group2b");
+    cy.testCreateUserAndGroup("RR_user2b", "RR_group2b");
 
     //re-register camera to 2nd group & store device details
     cy.apiDeviceReregister("RR_cam2", "RR_cam2", "RR_group2b").then(() => {
@@ -82,9 +82,9 @@ describe("Device reregister", () => {
         Users: [],
       };
       //verify new device listed in 2nd group
-      cy.apiCheckDevices("RR_user2b", [expectedDevice2b]);
+      cy.apiDevicesCheck("RR_user2b", [expectedDevice2b]);
       //verify old device is listed in 1st group as inactive
-      cy.apiCheckDevices("RR_user2", [expectedDevice2], { onlyActive: false });
+      cy.apiDevicesCheck("RR_user2", [expectedDevice2], { onlyActive: false });
     });
   });
 
@@ -93,7 +93,7 @@ describe("Device reregister", () => {
     let expectedDevice3b: ApiDevicesDevice;
 
     //register camera & store device details
-    cy.apiCreateUserGroupAndDevice("RR_user3", "RR_group3", "RR_cam3").then(
+    cy.testCreateUserGroupAndDevice("RR_user3", "RR_group3", "RR_cam3").then(
       () => {
         expectedDevice3 = {
           id: getCreds("RR_cam3").id,
@@ -105,7 +105,7 @@ describe("Device reregister", () => {
     );
 
     //second group
-    cy.apiCreateUserGroup("RR_user3b", "RR_group3b");
+    cy.testCreateUserAndGroup("RR_user3b", "RR_group3b");
 
     //re-register camera to 3nd group & store device details
     cy.apiDeviceReregister("RR_cam3", "RR_cam3b", "RR_group3b").then(() => {
@@ -116,9 +116,9 @@ describe("Device reregister", () => {
         Users: [],
       };
       //verify new device listed in 3nd group
-      cy.apiCheckDevices("RR_user3b", [expectedDevice3b]);
+      cy.apiDevicesCheck("RR_user3b", [expectedDevice3b]);
       //verify old device is listed in 1st group as inactive
-      cy.apiCheckDevices("RR_user3", [expectedDevice3], { onlyActive: false });
+      cy.apiDevicesCheck("RR_user3", [expectedDevice3], { onlyActive: false });
     });
   });
 
@@ -126,7 +126,7 @@ describe("Device reregister", () => {
     let expectedDevice5a: ApiDevicesDevice;
 
     //register camera & store device details
-    cy.apiCreateUserGroupAndDevice("RR_user5", "RR_group5", "RR_cam5a").then(
+    cy.testCreateUserGroupAndDevice("RR_user5", "RR_group5", "RR_cam5a").then(
       () => {
         expectedDevice5a = {
           id: getCreds("RR_cam5a").id,
@@ -138,7 +138,7 @@ describe("Device reregister", () => {
     );
 
     //another pre-existing camera
-    cy.apiCreateDevice("RR_cam5", "RR_group5");
+    cy.apiDeviceAdd("RR_cam5", "RR_group5");
 
     //attempt to rename camera with duplicate name rejected
     //TODO: This should really return 422-Unprocessable.  It is not malformed - just  breaks our rules
@@ -151,7 +151,7 @@ describe("Device reregister", () => {
       HTTP_BadRequest
     ).then(() => {
       //check old device unaltered
-      cy.apiCheckDevicesContains("RR_user5", [expectedDevice5a]);
+      cy.apiDevicesCheckContains("RR_user5", [expectedDevice5a]);
     });
   });
 
@@ -175,7 +175,7 @@ describe("Device reregister", () => {
   });
 
   it("Should be able to create a device name that has -, _, and spaces in it", () => {
-    cy.apiCreateUserGroupAndDevice("RR_user6", "RR_group6", "RR_cam6");
+    cy.testCreateUserGroupAndDevice("RR_user6", "RR_group6", "RR_cam6");
     cy.apiDeviceReregister("RR_cam6", "funny device1", "RR_default_group");
     cy.apiDeviceReregister(
       "funny device1",
@@ -217,14 +217,14 @@ describe("Device reregister", () => {
   });
 
   it("Reregistered device can keep default salt id", () => {
-    cy.apiCreateUserGroup("RR_user7", "RR_group7");
-    cy.apiCreateDevice("RR_cam7", "RR_group7").then(() => {
+    cy.testCreateUserAndGroup("RR_user7", "RR_group7");
+    cy.apiDeviceAdd("RR_cam7", "RR_group7").then(() => {
       const expectedDevice1 = {
         devicename: getTestName("RR_cam7"),
         groupname: getTestName("RR_group7"),
         saltId: getCreds("RR_cam7").id,
       };
-      cy.apiCheckDevicesQuery("RR_user7", [expectedDevice1], null, [
+      cy.apiDeviceQueryCheck("RR_user7", [expectedDevice1], null, [
         expectedDevice1,
       ]);
 
@@ -236,15 +236,15 @@ describe("Device reregister", () => {
         groupname: getTestName("RR_group7"),
         saltId: getCreds("RR_cam7").id,
       };
-      cy.apiCheckDevicesQuery("RR_user7", [expectedDevice2], null, [
+      cy.apiDeviceQueryCheck("RR_user7", [expectedDevice2], null, [
         expectedDevice2,
       ]);
     });
   });
 
   it("Reregistered device can keep specified salt id", () => {
-    cy.apiCreateUserGroup("RR_user8", "RR_group8");
-    cy.apiCreateDevice("specify salt", "RR_group8", 9997);
+    cy.testCreateUserAndGroup("RR_user8", "RR_group8");
+    cy.apiDeviceAdd("specify salt", "RR_group8", 9997);
     cy.apiDeviceReregister("specify salt", "specify salt2", "RR_group8");
 
     //Test with Salt Id = device id by default
@@ -253,7 +253,7 @@ describe("Device reregister", () => {
       groupname: getTestName("RR_group8"),
       saltId: 9997,
     };
-    cy.apiCheckDevicesQuery("RR_user8", [expectedDevice2], null, [
+    cy.apiDeviceQueryCheck("RR_user8", [expectedDevice2], null, [
       expectedDevice2,
     ]);
   });

--- a/integration-tests/cypress/integration/api/devices/device_reregister.ts
+++ b/integration-tests/cypress/integration/api/devices/device_reregister.ts
@@ -19,7 +19,7 @@ describe("Device reregister", () => {
       "RR_default_group",
       "RR_default_camera"
     );
-    cy.apiCreateGroup("Augustus", "RR_default_group_2", true);
+    cy.apiGroupAdd("Augustus", "RR_default_group_2", true);
   });
 
   it("re-register a device in same group with different name", () => {

--- a/integration-tests/cypress/integration/api/devices/device_users_add_remove.ts
+++ b/integration-tests/cypress/integration/api/devices/device_users_add_remove.ts
@@ -238,7 +238,7 @@ describe("Devices add / view / remove users", () => {
 
   it("Non-admin group member cannot add view or remove user to device", () => {
     // add non-admin user to group
-    cy.apiAddUserToGroup(groupAdmin, groupMember, group);
+    cy.apiGroupUserAdd(groupAdmin, groupMember, group);
 
     // non-admin cannot add another user
     cy.apiAddUserToDevice(groupMember, userB, camera, false, HTTP_Forbidden);
@@ -263,7 +263,7 @@ describe("Devices add / view / remove users", () => {
     ]);
 
     // remove user from group
-    cy.apiRemoveUserFromGroup(groupAdmin, groupMember, group);
+    cy.apiGroupUserRemove(groupAdmin, groupMember, group);
 
     // check user (but not group admin) has been removed
     cy.apiCheckDevicesUsers(groupAdmin, camera, [

--- a/integration-tests/cypress/integration/api/devices/device_users_add_remove.ts
+++ b/integration-tests/cypress/integration/api/devices/device_users_add_remove.ts
@@ -215,12 +215,7 @@ describe("Devices add / view / remove users", () => {
     cy.apiDeviceUserAdd(deviceMember, userB, camera, false, HTTP_Forbidden);
 
     // non-admin cannot remove a user
-    cy.apiDeviceUserRemove(
-      deviceMember,
-      deviceMember,
-      camera,
-      HTTP_Forbidden
-    );
+    cy.apiDeviceUserRemove(deviceMember, deviceMember, camera, HTTP_Forbidden);
 
     // check group member cannot see user details
     // TODO: FAIL - Issue 63 - request should be rejected with Forbidden if user does not have permissions, not return empty array
@@ -244,12 +239,7 @@ describe("Devices add / view / remove users", () => {
     cy.apiDeviceUserAdd(groupMember, userB, camera, false, HTTP_Forbidden);
 
     // non-admin cannot remove a user
-    cy.apiDeviceUserRemove(
-      groupMember,
-      deviceMember,
-      camera,
-      HTTP_Forbidden
-    );
+    cy.apiDeviceUserRemove(groupMember, deviceMember, camera, HTTP_Forbidden);
 
     // check group member cannot see user details
     // TODO: FAIL - Issue 63 - request should be rejected with Unauthorised if user does not have permissions, not return empty array
@@ -329,11 +319,6 @@ describe("Devices add / view / remove users", () => {
     );
 
     // remove non existant user from device
-    cy.apiDeviceUserRemove(
-      groupAdmin,
-      "bad-user",
-      camera,
-      HTTP_Unprocessable
-    );
+    cy.apiDeviceUserRemove(groupAdmin, "bad-user", camera, HTTP_Unprocessable);
   });
 });

--- a/integration-tests/cypress/integration/api/devices/device_users_add_remove.ts
+++ b/integration-tests/cypress/integration/api/devices/device_users_add_remove.ts
@@ -37,11 +37,11 @@ describe("Devices add / view / remove users", () => {
   let expectedDeviceInGroupUserView: ApiDeviceInGroupDevice;
 
   before(() => {
-    cy.apiCreateUser(groupMember);
-    cy.apiCreateUser(deviceMember);
-    cy.apiCreateUser(deviceAdmin);
-    cy.apiCreateUser(hacker);
-    cy.apiCreateUserGroupAndDevice(groupAdmin, group, camera).then(() => {
+    cy.apiUserAdd(groupMember);
+    cy.apiUserAdd(deviceMember);
+    cy.apiUserAdd(deviceAdmin);
+    cy.apiUserAdd(hacker);
+    cy.testCreateUserGroupAndDevice(groupAdmin, group, camera).then(() => {
       deviceMemberDetails = {
         id: getCreds(deviceMember).id,
         username: getTestName(deviceMember),
@@ -78,10 +78,10 @@ describe("Devices add / view / remove users", () => {
         users: null,
       };
     });
-    cy.apiAddUserToDevice(groupAdmin, deviceAdmin, camera, ADMIN);
+    cy.apiDeviceUserAdd(groupAdmin, deviceAdmin, camera, ADMIN);
 
     // second group users & device
-    cy.apiCreateUser(userC).then(() => {
+    cy.apiUserAdd(userC).then(() => {
       userCDetails = {
         id: getCreds(userC).id,
         username: getTestName(userC),
@@ -90,7 +90,7 @@ describe("Devices add / view / remove users", () => {
         admin: true,
       };
     });
-    cy.apiCreateUser(userD).then(() => {
+    cy.apiUserAdd(userD).then(() => {
       userDDetails = {
         id: getCreds(userD).id,
         username: getTestName(userD),
@@ -99,7 +99,7 @@ describe("Devices add / view / remove users", () => {
         admin: true,
       };
     });
-    cy.apiCreateUserGroupAndDevice(userB, group2, camera2).then(() => {
+    cy.testCreateUserGroupAndDevice(userB, group2, camera2).then(() => {
       userBDetails = {
         id: getCreds(userB).id,
         username: getTestName(userB),
@@ -112,17 +112,17 @@ describe("Devices add / view / remove users", () => {
 
   it("Group admin can add/remove user to/from device", () => {
     // add user to device
-    cy.apiAddUserToDevice(groupAdmin, deviceMember, camera);
+    cy.apiDeviceUserAdd(groupAdmin, deviceMember, camera);
 
     // check user (and group admin) are added
-    cy.apiCheckDevicesUsers(groupAdmin, camera, [
+    cy.apiDeviceUsersCheck(groupAdmin, camera, [
       groupAdminDetails,
       deviceAdminDetails,
       deviceMemberDetails,
     ]);
 
     // check user can access device (one endpoint only - test all endpoints in their own test specs )
-    cy.apiCheckDeviceInGroup(
+    cy.apiDeviceInGroupCheck(
       deviceMember,
       camera,
       group,
@@ -131,10 +131,10 @@ describe("Devices add / view / remove users", () => {
     );
 
     // check user can be removed from device
-    cy.apiRemoveUserFromDevice(groupAdmin, deviceMember, camera);
+    cy.apiDeviceUserRemove(groupAdmin, deviceMember, camera);
 
     // check user (but not group admin) has been removed
-    cy.apiCheckDevicesUsers(groupAdmin, camera, [
+    cy.apiDeviceUsersCheck(groupAdmin, camera, [
       deviceAdminDetails,
       groupAdminDetails,
     ]);
@@ -142,17 +142,17 @@ describe("Devices add / view / remove users", () => {
 
   it("Device admin can add/remove user to/from device", () => {
     // add user to device
-    cy.apiAddUserToDevice(deviceAdmin, deviceMember, camera);
+    cy.apiDeviceUserAdd(deviceAdmin, deviceMember, camera);
 
     // check user (and group admin) are added
-    cy.apiCheckDevicesUsers(deviceAdmin, camera, [
+    cy.apiDeviceUsersCheck(deviceAdmin, camera, [
       deviceAdminDetails,
       groupAdminDetails,
       deviceMemberDetails,
     ]);
 
     // check user can access device (one endpoint only - test all endpoints in their own test specs )
-    cy.apiCheckDeviceInGroup(
+    cy.apiDeviceInGroupCheck(
       deviceMember,
       camera,
       group,
@@ -161,10 +161,10 @@ describe("Devices add / view / remove users", () => {
     );
 
     // check user can be removed from device
-    cy.apiRemoveUserFromDevice(deviceAdmin, deviceMember, camera);
+    cy.apiDeviceUserRemove(deviceAdmin, deviceMember, camera);
 
     // check user (but not group admin) has been removed
-    cy.apiCheckDevicesUsers(deviceAdmin, camera, [
+    cy.apiDeviceUsersCheck(deviceAdmin, camera, [
       deviceAdminDetails,
       groupAdminDetails,
     ]);
@@ -176,17 +176,17 @@ describe("Devices add / view / remove users", () => {
       cy.apiSignInAs(null, null, superuser, suPassword);
 
       // add user to device
-      cy.apiAddUserToDevice(superuser, deviceMember, camera);
+      cy.apiDeviceUserAdd(superuser, deviceMember, camera);
 
       // check user (and group admin) are added
-      cy.apiCheckDevicesUsers(superuser, camera, [
+      cy.apiDeviceUsersCheck(superuser, camera, [
         deviceAdminDetails,
         groupAdminDetails,
         deviceMemberDetails,
       ]);
 
       // check user can access device (one endpoint only - test all endpoints in their own test specs )
-      cy.apiCheckDeviceInGroup(
+      cy.apiDeviceInGroupCheck(
         deviceMember,
         camera,
         group,
@@ -195,10 +195,10 @@ describe("Devices add / view / remove users", () => {
       );
 
       // check user can be removed from device
-      cy.apiRemoveUserFromDevice(superuser, deviceMember, camera);
+      cy.apiDeviceUserRemove(superuser, deviceMember, camera);
 
       // check user (but not group admin) has been removed
-      cy.apiCheckDevicesUsers(superuser, camera, [
+      cy.apiDeviceUsersCheck(superuser, camera, [
         deviceAdminDetails,
         groupAdminDetails,
       ]);
@@ -209,13 +209,13 @@ describe("Devices add / view / remove users", () => {
 
   it("Non-admin device member cannot add view or remove user to device", () => {
     // add non-admin user to device
-    cy.apiAddUserToDevice(groupAdmin, deviceMember, camera);
+    cy.apiDeviceUserAdd(groupAdmin, deviceMember, camera);
 
     // non-admin cannot add another user
-    cy.apiAddUserToDevice(deviceMember, userB, camera, false, HTTP_Forbidden);
+    cy.apiDeviceUserAdd(deviceMember, userB, camera, false, HTTP_Forbidden);
 
     // non-admin cannot remove a user
-    cy.apiRemoveUserFromDevice(
+    cy.apiDeviceUserRemove(
       deviceMember,
       deviceMember,
       camera,
@@ -224,13 +224,13 @@ describe("Devices add / view / remove users", () => {
 
     // check group member cannot see user details
     // TODO: FAIL - Issue 63 - request should be rejected with Forbidden if user does not have permissions, not return empty array
-    cy.apiCheckDevicesUsers(deviceMember, camera, []);
+    cy.apiDeviceUsersCheck(deviceMember, camera, []);
 
     // check user can be removed from device
-    cy.apiRemoveUserFromDevice(groupAdmin, deviceMember, camera);
+    cy.apiDeviceUserRemove(groupAdmin, deviceMember, camera);
 
     // check user (but not group admin) has been removed
-    cy.apiCheckDevicesUsers(groupAdmin, camera, [
+    cy.apiDeviceUsersCheck(groupAdmin, camera, [
       deviceAdminDetails,
       groupAdminDetails,
     ]);
@@ -241,10 +241,10 @@ describe("Devices add / view / remove users", () => {
     cy.apiGroupUserAdd(groupAdmin, groupMember, group);
 
     // non-admin cannot add another user
-    cy.apiAddUserToDevice(groupMember, userB, camera, false, HTTP_Forbidden);
+    cy.apiDeviceUserAdd(groupMember, userB, camera, false, HTTP_Forbidden);
 
     // non-admin cannot remove a user
-    cy.apiRemoveUserFromDevice(
+    cy.apiDeviceUserRemove(
       groupMember,
       deviceMember,
       camera,
@@ -253,10 +253,10 @@ describe("Devices add / view / remove users", () => {
 
     // check group member cannot see user details
     // TODO: FAIL - Issue 63 - request should be rejected with Unauthorised if user does not have permissions, not return empty array
-    cy.apiCheckDevicesUsers(groupMember, camera, []);
+    cy.apiDeviceUsersCheck(groupMember, camera, []);
 
     // check admin member can see ggroup member
-    cy.apiCheckDevicesUsers(groupAdmin, camera, [
+    cy.apiDeviceUsersCheck(groupAdmin, camera, [
       groupMemberDetails,
       deviceAdminDetails,
       groupAdminDetails,
@@ -266,7 +266,7 @@ describe("Devices add / view / remove users", () => {
     cy.apiGroupUserRemove(groupAdmin, groupMember, group);
 
     // check user (but not group admin) has been removed
-    cy.apiCheckDevicesUsers(groupAdmin, camera, [
+    cy.apiDeviceUsersCheck(groupAdmin, camera, [
       deviceAdminDetails,
       groupAdminDetails,
     ]);
@@ -274,7 +274,7 @@ describe("Devices add / view / remove users", () => {
 
   it("Admin cannot add or remove user to another device", () => {
     // cannot add user to another group's devices
-    cy.apiAddUserToDevice(
+    cy.apiDeviceUserAdd(
       groupAdmin,
       deviceMember,
       camera2,
@@ -283,30 +283,30 @@ describe("Devices add / view / remove users", () => {
     );
 
     // but group member can add group user
-    cy.apiAddUserToDevice(userB, userC, camera2, true);
+    cy.apiDeviceUserAdd(userB, userC, camera2, true);
 
     // admin can't remove another groups users
-    cy.apiRemoveUserFromDevice(groupAdmin, userB, camera2, HTTP_Forbidden);
+    cy.apiDeviceUserRemove(groupAdmin, userB, camera2, HTTP_Forbidden);
 
     // check both users are there (delete failed)
-    cy.apiCheckDevicesUsers(userB, camera2, [userBDetails, userCDetails]);
+    cy.apiDeviceUsersCheck(userB, camera2, [userBDetails, userCDetails]);
 
     // but device member can remove themselves
-    cy.apiRemoveUserFromDevice(userC, userC, camera2);
+    cy.apiDeviceUserRemove(userC, userC, camera2);
 
     // check user (but not group admin) has been removed
-    cy.apiCheckDevicesUsers(userB, camera2, [userBDetails]);
+    cy.apiDeviceUsersCheck(userB, camera2, [userBDetails]);
   });
 
   it("Can create a device admin-user who can then manage users", () => {
     // create an admin device user
-    cy.apiAddUserToDevice(groupAdmin, userC, camera, true);
+    cy.apiDeviceUserAdd(groupAdmin, userC, camera, true);
 
     // device admin user can add another user
-    cy.apiAddUserToDevice(userC, userD, camera, true);
+    cy.apiDeviceUserAdd(userC, userD, camera, true);
 
     // check both users are there (delete failed)
-    cy.apiCheckDevicesUsers(userC, camera, [
+    cy.apiDeviceUsersCheck(userC, camera, [
       deviceAdminDetails,
       groupAdminDetails,
       userCDetails,
@@ -314,13 +314,13 @@ describe("Devices add / view / remove users", () => {
     ]);
 
     // Remove test users dfrom device
-    cy.apiRemoveUserFromDevice(userC, userD, camera);
-    cy.apiRemoveUserFromDevice(userC, userC, camera);
+    cy.apiDeviceUserRemove(userC, userD, camera);
+    cy.apiDeviceUserRemove(userC, userC, camera);
   });
 
   it("Invalid usernames rejected", () => {
     // add non existant user to device
-    cy.apiAddUserToDevice(
+    cy.apiDeviceUserAdd(
       groupAdmin,
       "bad-user",
       camera,
@@ -329,7 +329,7 @@ describe("Devices add / view / remove users", () => {
     );
 
     // remove non existant user from device
-    cy.apiRemoveUserFromDevice(
+    cy.apiDeviceUserRemove(
       groupAdmin,
       "bad-user",
       camera,

--- a/integration-tests/cypress/integration/api/devices/devices.ts
+++ b/integration-tests/cypress/integration/api/devices/devices.ts
@@ -33,11 +33,11 @@ describe("Devices list", () => {
   let expectedDevice4AdminView: ApiDevicesDevice;
 
   before(() => {
-    cy.apiCreateUser(groupMember);
-    cy.apiCreateUser(deviceAdmin);
-    cy.apiCreateUser(deviceMember);
-    cy.apiCreateUser(hacker);
-    cy.apiCreateUserGroupAndDevice(groupAdmin, group, camera).then(() => {
+    cy.apiUserAdd(groupMember);
+    cy.apiUserAdd(deviceAdmin);
+    cy.apiUserAdd(deviceMember);
+    cy.apiUserAdd(hacker);
+    cy.testCreateUserGroupAndDevice(groupAdmin, group, camera).then(() => {
       expectedDeviceAdminView = {
         id: getCreds(camera).id,
         devicename: getTestName(camera),
@@ -71,11 +71,11 @@ describe("Devices list", () => {
       };
     });
     cy.apiGroupUserAdd(groupAdmin, groupMember, group, NOT_ADMIN);
-    cy.apiAddUserToDevice(groupAdmin, deviceMember, camera);
-    cy.apiAddUserToDevice(groupAdmin, deviceAdmin, camera, ADMIN);
+    cy.apiDeviceUserAdd(groupAdmin, deviceMember, camera);
+    cy.apiDeviceUserAdd(groupAdmin, deviceAdmin, camera, ADMIN);
 
     //second group
-    cy.apiCreateUserGroupAndDevice(user2, group2, camera2).then(() => {
+    cy.testCreateUserGroupAndDevice(user2, group2, camera2).then(() => {
       expectedDevice2AdminView = {
         id: getCreds(camera2).id,
         devicename: getTestName(camera2),
@@ -85,8 +85,8 @@ describe("Devices list", () => {
     });
 
     //reregistered device
-    cy.apiCreateUserGroupAndDevice(user3, group3, camera3);
-    cy.apiAddUserToDevice(user3, user3, camera3);
+    cy.testCreateUserGroupAndDevice(user3, group3, camera3);
+    cy.apiDeviceUserAdd(user3, user3, camera3);
     cy.apiDeviceReregister(camera3, camera4, group3).then(() => {
       expectedDevice3AdminView = {
         id: getCreds(camera3).id,
@@ -125,7 +125,7 @@ describe("Devices list", () => {
         Users: [],
       };
 
-      cy.apiCheckDevicesContains(superuser, [
+      cy.apiDevicesCheckContains(superuser, [
         expectedDeviceAdminView,
         expectedDevice2AdminView,
       ]);
@@ -153,7 +153,7 @@ describe("Devices list", () => {
         user2
       );
 
-      cy.apiCheckDevices(superuser, [expectedDevice2AdminView], {
+      cy.apiDevicesCheck(superuser, [expectedDevice2AdminView], {
         "view-mode": "user",
       });
 
@@ -175,35 +175,35 @@ describe("Devices list", () => {
   }
 
   it("Group admin should see everything including device users", () => {
-    cy.apiCheckDevices(groupAdmin, [expectedDeviceAdminView]);
+    cy.apiDevicesCheck(groupAdmin, [expectedDeviceAdminView]);
   });
 
   it("Group member should be able to read all but device users", () => {
     // TODO: View of users is allowed here but not in single device view.  Issue 62. Enable member view when fixed
-    //cy.apiCheckDevices(groupMember, [expectedDeviceMemberView]);
-    cy.apiCheckDevices(groupMember, [expectedDeviceAdminView]);
+    //cy.apiDevicesCheck(groupMember, [expectedDeviceMemberView]);
+    cy.apiDevicesCheck(groupMember, [expectedDeviceAdminView]);
   });
 
   it("Device admin should see everything including device users", () => {
-    cy.apiCheckDevices(deviceAdmin, [expectedDeviceAdminView]);
+    cy.apiDevicesCheck(deviceAdmin, [expectedDeviceAdminView]);
   });
 
   it("Device member should be able to read all but device users", () => {
     // TODO: View of users is allowed here but not in single device view.  Issue 62. Enable member view when fixed
-    //cy.apiCheckDevices(deviceMember, [expectedDeviceMemberView]);
-    cy.apiCheckDevices(deviceMember, [expectedDeviceAdminView]);
+    //cy.apiDevicesCheck(deviceMember, [expectedDeviceMemberView]);
+    cy.apiDevicesCheck(deviceMember, [expectedDeviceAdminView]);
   });
 
   it("Non member should not have any access to any devices", () => {
-    cy.apiCheckDevices(hacker, []);
+    cy.apiDevicesCheck(hacker, []);
   });
 
   it("Should display inactive devices only when requested", () => {
     //verify inactive device is not shown by default
-    cy.apiCheckDevices(user3, [expectedDevice4AdminView]);
+    cy.apiDevicesCheck(user3, [expectedDevice4AdminView]);
 
     //verify inactive device is shown when inactive is requested
-    cy.apiCheckDevices(
+    cy.apiDevicesCheck(
       user3,
       [expectedDevice3AdminView, expectedDevice4AdminView],
       { onlyActive: false }

--- a/integration-tests/cypress/integration/api/devices/devices.ts
+++ b/integration-tests/cypress/integration/api/devices/devices.ts
@@ -70,7 +70,7 @@ describe("Devices list", () => {
         Users: null,
       };
     });
-    cy.apiAddUserToGroup(groupAdmin, groupMember, group, NOT_ADMIN);
+    cy.apiGroupUserAdd(groupAdmin, groupMember, group, NOT_ADMIN);
     cy.apiAddUserToDevice(groupAdmin, deviceMember, camera);
     cy.apiAddUserToDevice(groupAdmin, deviceAdmin, camera, ADMIN);
 

--- a/integration-tests/cypress/integration/api/events/errors_query.ts
+++ b/integration-tests/cypress/integration/api/events/errors_query.ts
@@ -160,7 +160,7 @@ describe("Events - query errors", () => {
     // group with 2 devices, admin and member users
     cy.apiCreateUserGroupAndDevice("erGroupAdmin", "erGroup", "erCamera");
     cy.apiCreateUser("erGroupMember");
-    cy.apiAddUserToGroup("erGroupAdmin", "erGroupMember", "erGroup", NOT_ADMIN);
+    cy.apiGroupUserAdd("erGroupAdmin", "erGroupMember", "erGroup", NOT_ADMIN);
     cy.apiCreateDevice("erOtherCamera", "erGroup");
 
     //admin and member for single device

--- a/integration-tests/cypress/integration/api/events/errors_query.ts
+++ b/integration-tests/cypress/integration/api/events/errors_query.ts
@@ -158,16 +158,16 @@ describe("Events - query errors", () => {
 
   before(() => {
     // group with 2 devices, admin and member users
-    cy.apiCreateUserGroupAndDevice("erGroupAdmin", "erGroup", "erCamera");
-    cy.apiCreateUser("erGroupMember");
+    cy.testCreateUserGroupAndDevice("erGroupAdmin", "erGroup", "erCamera");
+    cy.apiUserAdd("erGroupMember");
     cy.apiGroupUserAdd("erGroupAdmin", "erGroupMember", "erGroup", NOT_ADMIN);
-    cy.apiCreateDevice("erOtherCamera", "erGroup");
+    cy.apiDeviceAdd("erOtherCamera", "erGroup");
 
     //admin and member for single device
-    cy.apiCreateUser("erDeviceAdmin");
-    cy.apiCreateUser("erDeviceMember");
-    cy.apiAddUserToDevice("erGroupAdmin", "erDeviceAdmin", "erCamera", ADMIN);
-    cy.apiAddUserToDevice(
+    cy.apiUserAdd("erDeviceAdmin");
+    cy.apiUserAdd("erDeviceMember");
+    cy.apiDeviceUserAdd("erGroupAdmin", "erDeviceAdmin", "erCamera", ADMIN);
+    cy.apiDeviceUserAdd(
       "erGroupAdmin",
       "erDeviceMember",
       "erCamera",
@@ -175,7 +175,7 @@ describe("Events - query errors", () => {
     );
 
     //another group and device
-    cy.apiCreateUserGroupAndDevice(
+    cy.testCreateUserGroupAndDevice(
       "erOtherGroupAdmin",
       "erOherGroup",
       "erOtherGroupCamera"

--- a/integration-tests/cypress/integration/api/events/events.ts
+++ b/integration-tests/cypress/integration/api/events/events.ts
@@ -20,9 +20,9 @@ describe("Events - add event as a device", () => {
   };
 
   before(() => {
-    cy.apiCreateUserGroupAndDevice("evGroupAdmin", "evGroup", "evCamera");
-    cy.apiCreateUserGroupAndDevice("evGroupAdmin2", "evGroup2", "evCamera2");
-    cy.apiCreateUserGroupAndDevice("evGroupAdmin8", "evGroup8", "evCamera8");
+    cy.testCreateUserGroupAndDevice("evGroupAdmin", "evGroup", "evCamera");
+    cy.testCreateUserGroupAndDevice("evGroupAdmin2", "evGroup2", "evCamera2");
+    cy.testCreateUserGroupAndDevice("evGroupAdmin8", "evGroup8", "evCamera8");
 
     //Create some events to reuse / query
     cy.apiEventsAdd("evCamera", eventDetails1, [time1]).then(

--- a/integration-tests/cypress/integration/api/events/events_on_behalf.ts
+++ b/integration-tests/cypress/integration/api/events/events_on_behalf.ts
@@ -89,7 +89,7 @@ describe("Events - add event on behalf of device", () => {
       Device: { devicename: getTestName("camera2") },
       EventDetail: { type: EventTypes.POWERED_ON, details: {} },
     };
-    cy.apiAddUserToGroup("groupAdmin2", "groupMember2", "group2", false);
+    cy.apiGroupUserAdd("groupAdmin2", "groupMember2", "group2", false);
 
     // add and verify events
     cy.apiEventsDeviceAddOnBehalf(

--- a/integration-tests/cypress/integration/api/events/events_on_behalf.ts
+++ b/integration-tests/cypress/integration/api/events/events_on_behalf.ts
@@ -24,17 +24,17 @@ describe("Events - add event on behalf of device", () => {
   };
 
   before(() => {
-    cy.apiCreateUserGroupAndDevice("groupAdmin", "group", "camera");
-    cy.apiCreateUserGroupAndDevice("groupAdmin1", "group1", "camera1");
-    cy.apiCreateUserGroupAndDevice("groupAdmin2", "group2", "camera2");
-    cy.apiCreateUserGroupAndDevice("groupAdmin3", "group3", "camera3");
-    cy.apiCreateUserGroupAndDevice("groupAdmin4", "group4", "camera4");
-    cy.apiCreateUserGroupAndDevice("groupAdmin8", "group8", "camera8");
-    cy.apiCreateUserGroupAndDevice("groupAdmin9", "group9", "camera9");
-    cy.apiCreateDevice("otherCamera", "group");
-    cy.apiCreateUser("deviceAdmin");
-    cy.apiAddUserToDevice("groupAdmin", "deviceAdmin", "camera", true);
-    cy.apiCreateUserGroupAndDevice(
+    cy.testCreateUserGroupAndDevice("groupAdmin", "group", "camera");
+    cy.testCreateUserGroupAndDevice("groupAdmin1", "group1", "camera1");
+    cy.testCreateUserGroupAndDevice("groupAdmin2", "group2", "camera2");
+    cy.testCreateUserGroupAndDevice("groupAdmin3", "group3", "camera3");
+    cy.testCreateUserGroupAndDevice("groupAdmin4", "group4", "camera4");
+    cy.testCreateUserGroupAndDevice("groupAdmin8", "group8", "camera8");
+    cy.testCreateUserGroupAndDevice("groupAdmin9", "group9", "camera9");
+    cy.apiDeviceAdd("otherCamera", "group");
+    cy.apiUserAdd("deviceAdmin");
+    cy.apiDeviceUserAdd("groupAdmin", "deviceAdmin", "camera", true);
+    cy.testCreateUserGroupAndDevice(
       "otherGroupAdmin",
       "otherGroup",
       "otherGroupCamera"
@@ -80,7 +80,7 @@ describe("Events - add event on behalf of device", () => {
   });
 
   it("Group member can add event on behalf of device", () => {
-    cy.apiCreateUser("groupMember2");
+    cy.apiUserAdd("groupMember2");
     const expectedEvent2 = {
       id: null,
       createdAt: null,
@@ -108,8 +108,8 @@ describe("Events - add event on behalf of device", () => {
   });
 
   it("Device admin can add event on behalf of device", () => {
-    cy.apiCreateUser("deviceAdmin3");
-    cy.apiAddUserToDevice("groupAdmin3", "deviceAdmin3", "camera3", true);
+    cy.apiUserAdd("deviceAdmin3");
+    cy.apiDeviceUserAdd("groupAdmin3", "deviceAdmin3", "camera3", true);
     const expectedEvent3 = {
       id: null,
       createdAt: null,
@@ -136,8 +136,8 @@ describe("Events - add event on behalf of device", () => {
   });
 
   it("Device member can add event on behalf of device", () => {
-    cy.apiCreateUser("deviceMember4");
-    cy.apiAddUserToDevice("groupAdmin4", "deviceMember4", "camera4", true);
+    cy.apiUserAdd("deviceMember4");
+    cy.apiDeviceUserAdd("groupAdmin4", "deviceMember4", "camera4", true);
     const expectedEvent4 = {
       id: null,
       createdAt: null,
@@ -507,7 +507,7 @@ describe("Events - add event on behalf of device", () => {
   it("Cannot upload event by devicename where duplicate devicenames exist", () => {
     const timeNow = new Date().toISOString();
     cy.log("duplicate camera name");
-    cy.apiCreateUserGroupAndDevice("groupAdmin10", "group10", "camera");
+    cy.testCreateUserGroupAndDevice("groupAdmin10", "group10", "camera");
     cy.apiEventsDeviceAddOnBehalf(
       "groupAdmin10",
       getTestName("camera"),

--- a/integration-tests/cypress/integration/api/events/events_query.ts
+++ b/integration-tests/cypress/integration/api/events/events_query.ts
@@ -34,19 +34,19 @@ describe("Events - query events", () => {
 
   before(() => {
     // group with 2 devices, admin and member users
-    cy.apiCreateUserGroupAndDevice("eqGroupAdmin", "eqGroup", "eqCamera");
-    cy.apiCreateUser("eqGroupMember");
+    cy.testCreateUserGroupAndDevice("eqGroupAdmin", "eqGroup", "eqCamera");
+    cy.apiUserAdd("eqGroupMember");
     cy.apiGroupUserAdd("eqGroupAdmin", "eqGroupMember", "eqGroup", false);
-    cy.apiCreateDevice("eqOtherCamera", "eqGroup");
+    cy.apiDeviceAdd("eqOtherCamera", "eqGroup");
 
     //admin and member for single device
-    cy.apiCreateUser("eqDeviceAdmin");
-    cy.apiCreateUser("eqDeviceMember");
-    cy.apiAddUserToDevice("eqGroupAdmin", "eqDeviceAdmin", "eqCamera", true);
-    cy.apiAddUserToDevice("eqGroupAdmin", "eqDeviceMember", "eqCamera", true);
+    cy.apiUserAdd("eqDeviceAdmin");
+    cy.apiUserAdd("eqDeviceMember");
+    cy.apiDeviceUserAdd("eqGroupAdmin", "eqDeviceAdmin", "eqCamera", true);
+    cy.apiDeviceUserAdd("eqGroupAdmin", "eqDeviceMember", "eqCamera", true);
 
     //another group and device
-    cy.apiCreateUserGroupAndDevice(
+    cy.testCreateUserGroupAndDevice(
       "eqOtherGroupAdmin",
       "eqOherGroup",
       "eqOtherGroupCamera"

--- a/integration-tests/cypress/integration/api/events/events_query.ts
+++ b/integration-tests/cypress/integration/api/events/events_query.ts
@@ -36,7 +36,7 @@ describe("Events - query events", () => {
     // group with 2 devices, admin and member users
     cy.apiCreateUserGroupAndDevice("eqGroupAdmin", "eqGroup", "eqCamera");
     cy.apiCreateUser("eqGroupMember");
-    cy.apiAddUserToGroup("eqGroupAdmin", "eqGroupMember", "eqGroup", false);
+    cy.apiGroupUserAdd("eqGroupAdmin", "eqGroupMember", "eqGroup", false);
     cy.apiCreateDevice("eqOtherCamera", "eqGroup");
 
     //admin and member for single device

--- a/integration-tests/cypress/integration/api/events/power_events_query.ts
+++ b/integration-tests/cypress/integration/api/events/power_events_query.ts
@@ -47,7 +47,7 @@ describe("Events - query power events", () => {
     // group with 2 devices, admin and member users
     cy.apiCreateUserGroupAndDevice("peGroupAdmin", "peGroup", "peCamera");
     cy.apiCreateUser("peGroupMember");
-    cy.apiAddUserToGroup("peGroupAdmin", "peGroupMember", "peGroup", false);
+    cy.apiGroupUserAdd("peGroupAdmin", "peGroupMember", "peGroup", false);
     cy.apiCreateDevice("peOtherCamera", "peGroup");
 
     //admin and member for single device

--- a/integration-tests/cypress/integration/api/events/power_events_query.ts
+++ b/integration-tests/cypress/integration/api/events/power_events_query.ts
@@ -45,19 +45,19 @@ describe("Events - query power events", () => {
 
   before(() => {
     // group with 2 devices, admin and member users
-    cy.apiCreateUserGroupAndDevice("peGroupAdmin", "peGroup", "peCamera");
-    cy.apiCreateUser("peGroupMember");
+    cy.testCreateUserGroupAndDevice("peGroupAdmin", "peGroup", "peCamera");
+    cy.apiUserAdd("peGroupMember");
     cy.apiGroupUserAdd("peGroupAdmin", "peGroupMember", "peGroup", false);
-    cy.apiCreateDevice("peOtherCamera", "peGroup");
+    cy.apiDeviceAdd("peOtherCamera", "peGroup");
 
     //admin and member for single device
-    cy.apiCreateUser("peDeviceAdmin");
-    cy.apiCreateUser("peDeviceMember");
-    cy.apiAddUserToDevice("peGroupAdmin", "peDeviceAdmin", "peCamera", true);
-    cy.apiAddUserToDevice("peGroupAdmin", "peDeviceMember", "peCamera", true);
+    cy.apiUserAdd("peDeviceAdmin");
+    cy.apiUserAdd("peDeviceMember");
+    cy.apiDeviceUserAdd("peGroupAdmin", "peDeviceAdmin", "peCamera", true);
+    cy.apiDeviceUserAdd("peGroupAdmin", "peDeviceMember", "peCamera", true);
 
     //another group and device
-    cy.apiCreateUserGroupAndDevice(
+    cy.testCreateUserGroupAndDevice(
       "peOtherGroupAdmin",
       "peOtherGroup",
       "peOtherGroupCamera"

--- a/integration-tests/cypress/integration/api/groups/groups_add_get.ts
+++ b/integration-tests/cypress/integration/api/groups/groups_add_get.ts
@@ -23,7 +23,7 @@ describe("Groups - add, get group", () => {
 
   before(() => {
     //admin user, group and device
-    cy.apiCreateUserGroupAndDevice("gaGroupAdmin", "gaGroup", "gaCamera").then(() => {
+    cy.testCreateUserGroupAndDevice("gaGroupAdmin", "gaGroup", "gaCamera").then(() => {
         expectedGroup={id:getCreds("gaGroup").id,groupname: getTestName("gaGroup"), 
 		Users: [],
 		Devices: [],
@@ -37,12 +37,12 @@ describe("Groups - add, get group", () => {
     });
 
     //2nd device in this group
-    cy.apiCreateDevice("gaCamera1b","gaGroup").then(() => {
+    cy.apiDeviceAdd("gaCamera1b","gaGroup").then(() => {
       expectedDevice1b={id: getCreds("gaCamera1b").id, devicename: getTestName("gaCamera1b")};
     });
 
     //group member for this group
-    cy.apiCreateUser("gaGroupMember");
+    cy.apiUserAdd("gaGroupMember");
     cy.apiGroupUserAdd("gaGroupAdmin", "gaGroupMember", "gaGroup", NOT_ADMIN).then(() => {
       expectedGroupMemberUser={id: getCreds("gaGroupMember").id, username: getTestName("gaGroupMember"), GroupUsers:
             {admin: false, createdAt:"", updatedAt:"", GroupId: getCreds("gaGroup").id, UserId: getCreds("gaGroupMember").id}};
@@ -50,12 +50,12 @@ describe("Groups - add, get group", () => {
     });
 
     //device admin for 1st device
-    cy.apiCreateUser("gaDeviceAdmin");
-    cy.apiAddUserToDevice("gaGroupAdmin", "gaDeviceAdmin", "gaCamera", ADMIN);
+    cy.apiUserAdd("gaDeviceAdmin");
+    cy.apiDeviceUserAdd("gaGroupAdmin", "gaDeviceAdmin", "gaCamera", ADMIN);
 
     // test users
-    cy.apiCreateUser("gaTestUser");
-    cy.apiCreateUser("gaTestUser2");
+    cy.apiUserAdd("gaTestUser");
+    cy.apiUserAdd("gaTestUser2");
   });
 
   it("Can add a new group", () => {

--- a/integration-tests/cypress/integration/api/groups/groups_add_get.ts
+++ b/integration-tests/cypress/integration/api/groups/groups_add_get.ts
@@ -1,0 +1,155 @@
+/// <reference path="../../../support/index.d.ts" />
+
+import { ApiGroupReturned, ApiGroupUserRelation, ApiDeviceIdAndName, ApiGroupUser } from "../../../commands/types";
+import { getTestName } from "../../../commands/names";
+import { getCreds } from "../../../commands/server";
+
+import { HTTP_OK200 } from "../../../commands/constants";
+import { HTTP_Unprocessable } from "../../../commands/constants";
+import { HTTP_Forbidden } from "../../../commands/constants";
+
+const ADMIN=true;
+const NOT_ADMIN=false;
+let expectedGroup:ApiGroupReturned;
+let expectedGroupAdminUser:ApiGroupUserRelation;
+let expectedGroupAdminGroupUser:ApiGroupUser;
+let expectedGroupMemberUser:ApiGroupUserRelation;
+let expectedGroupMemberGroupUser:ApiGroupUser;
+let expectedDevice:ApiDeviceIdAndName;
+let expectedDevice1b:ApiDeviceIdAndName;
+const EXCLUDE_CREATED_UPDATED_AT=["[].Users[].GroupUsers.createdAt","[].Users[].GroupUsers.updatedAt"];
+
+describe("Groups - add, get group", () => {
+
+  before(() => {
+    //admin user, group and device
+    cy.apiCreateUserGroupAndDevice("gaGroupAdmin", "gaGroup", "gaCamera").then(() => {
+        expectedGroup={id:getCreds("gaGroup").id,groupname: getTestName("gaGroup"), 
+		Users: [],
+		Devices: [],
+		GroupUsers: []
+	};
+	expectedDevice={id: getCreds("gaCamera").id, devicename: getTestName("gaCamera")}
+	expectedGroupAdminUser={id: getCreds("gaGroupAdmin").id, username: getTestName("gaGroupAdmin"), GroupUsers: 
+          {admin: true, createdAt:"", updatedAt:"", GroupId: getCreds("gaGroup").id, UserId: getCreds("gaGroupAdmin").id}};
+        expectedGroupAdminGroupUser={id: getCreds("gaGroupAdmin").id, username: getTestName("gaGroupAdmin"), isAdmin:true};
+
+    });
+
+    //2nd device in this group
+    cy.apiCreateDevice("gaCamera1b","gaGroup").then(() => {
+      expectedDevice1b={id: getCreds("gaCamera1b").id, devicename: getTestName("gaCamera1b")};
+    });
+
+    //group member for this group
+    cy.apiCreateUser("gaGroupMember");
+    cy.apiGroupUserAdd("gaGroupAdmin", "gaGroupMember", "gaGroup", NOT_ADMIN).then(() => {
+      expectedGroupMemberUser={id: getCreds("gaGroupMember").id, username: getTestName("gaGroupMember"), GroupUsers:
+            {admin: false, createdAt:"", updatedAt:"", GroupId: getCreds("gaGroup").id, UserId: getCreds("gaGroupMember").id}};
+      expectedGroupMemberGroupUser={id: getCreds("gaGroupMember").id, username: getTestName("gaGroupMember"), isAdmin:false};
+    });
+
+    //device admin for 1st device
+    cy.apiCreateUser("gaDeviceAdmin");
+    cy.apiAddUserToDevice("gaGroupAdmin", "gaDeviceAdmin", "gaCamera", ADMIN);
+
+    // test users
+    cy.apiCreateUser("gaTestUser");
+    cy.apiCreateUser("gaTestUser2");
+  });
+
+  it("Can add a new group", () => {
+    let expectedTestGroup:ApiGroupReturned;
+    cy.log("Create a new group");
+    cy.apiGroupAdd("gaTestUser","gaTestGroup1",true).then(() => {
+	let expectedTestGroupUser={id: getCreds("gaTestUser").id, username: getTestName("gaTestUser"), GroupUsers: 
+          {admin: true, createdAt:"", updatedAt:"", GroupId: getCreds("gaTestGroup1").id, UserId: getCreds("gaTestUser").id}};
+        let expectedTestGroupGroupUser={id: getCreds("gaTestUser").id, username: getTestName("gaTestUser"), isAdmin:true};
+        expectedTestGroup={id:getCreds("gaTestGroup1").id,groupname: getTestName("gaTestGroup1"), 
+		Users: [expectedTestGroupUser],
+		Devices: [],
+		GroupUsers: [expectedTestGroupGroupUser]
+	};
+
+        cy.log("Group creator can view the created group");
+	//group query
+        cy.apiGroupCheck("gaTestUser", "gaTestGroup1", [expectedTestGroup], EXCLUDE_CREATED_UPDATED_AT);
+    });
+  });
+
+  it("Admin and member can view group's devices and users", () => {
+     expectedGroup.Devices=[expectedDevice, expectedDevice1b];
+     expectedGroup.GroupUsers=[expectedGroupAdminGroupUser, expectedGroupMemberGroupUser];
+     let expectedGroup2=JSON.parse(JSON.stringify(expectedGroup));
+
+     cy.log("Check admin can view group, devices and user");
+     expectedGroup.Users=[expectedGroupAdminUser];
+     cy.apiGroupCheck("gaGroupAdmin", "gaGroup", [expectedGroup], EXCLUDE_CREATED_UPDATED_AT);
+
+     cy.log("Check member can view group, devices and user");
+     expectedGroup2.Users=[expectedGroupMemberUser];
+     cy.apiGroupCheck("gaGroupMember", "gaGroup", [expectedGroup2], EXCLUDE_CREATED_UPDATED_AT);
+  });
+
+
+  it("Can query using group id", () => {
+    expectedGroup.Devices=[expectedDevice, expectedDevice1b];
+    expectedGroup.GroupUsers=[expectedGroupAdminGroupUser, expectedGroupMemberGroupUser];
+    expectedGroup.Users=[expectedGroupAdminUser];
+    //Query using group id
+    cy.apiGroupCheck("gaGroupAdmin", getCreds("gaGroup").id.toString(), [expectedGroup], EXCLUDE_CREATED_UPDATED_AT,HTTP_OK200, {useRawGroupName: true});
+
+  });
+
+  it("Non member cannot query", () => {
+    //TODO: This behaviou ris inconsistent with other API endpoints.  Most return 403 to requests the user has
+    // no permission for. Thuis one returns 200 and an empty result. Issue 
+    cy.log("Valid user with no access to this group");
+//    cy.apiGroupCheck("gaTestUser", "gaGroup", [], [], HTTP_Forbidden);   
+    cy.apiGroupCheck("gaTestUser", "gaGroup", [], [], HTTP_OK200);   
+
+    cy.log("Device admin with no group-level permisssions");
+//    cy.apiGroupCheck("gaDeviceAdmin", "gaGroup", [], [], HTTP_Forbidden);
+    cy.apiGroupCheck("gaDeviceAdmin", "gaGroup", [], [], HTTP_OK200);
+
+    cy.log("Valid user with no access to this group using groupId");
+//    cy.apiGroupCheck("gaTestUser", getCreds("gaGroup").id.toString(), [], [], HTTP_Forbidden, {useRawGroupName: true});
+    cy.apiGroupCheck("gaTestUser", getCreds("gaGroup").id.toString(), [], [], HTTP_OK200, {useRawGroupName: true});
+  });
+
+  it("Query nonexistant group handled correctly", () => {
+    cy.apiGroupCheck("gaGroupAdmin", "IDontExist", [], [], HTTP_Unprocessable, {useRawGroupName: true});
+
+    cy.apiGroupCheck("gaGroupAdmin", "9999999", [], [], HTTP_Unprocessable, {useRawGroupName: true});
+  });
+
+  it("Cannot create group with same name (even with different case)", () => {
+    cy.log("Add duplicate group (same user)");
+    cy.apiGroupAdd("gaGroupAdmin","gaGroup",true,HTTP_Unprocessable);
+    cy.log("Add duplicate group (different user)");
+    cy.apiGroupAdd("gaTestUser","gaGroup",true,HTTP_Unprocessable);
+    cy.log("Add duplicate group (different case)");
+    cy.apiGroupAdd("gaGroupAdmin","GAGROUP",true,HTTP_Unprocessable);
+  });
+  it("Invalid group names rejected", () => {
+    cy.log("Cannot add group with no letters");
+    cy.apiGroupAdd("gaGroupAdmin","",true,HTTP_Unprocessable,{useRawGroupName: true});
+    cy.apiGroupAdd("gaGroupAdmin","1234",true,HTTP_Unprocessable,{useRawGroupName: true});
+
+    cy.log("Cannot add group with other non-alphanumeric characters");
+    cy.apiGroupAdd("gaGroupAdmin","ABC%",true,HTTP_Unprocessable,{useRawGroupName: true});
+    cy.apiGroupAdd("gaGroupAdmin","ABC&",true,HTTP_Unprocessable,{useRawGroupName: true});
+    cy.apiGroupAdd("gaGroupAdmin","ABC<",true,HTTP_Unprocessable,{useRawGroupName: true});
+    cy.apiGroupAdd("gaGroupAdmin","ABC>",true,HTTP_Unprocessable,{useRawGroupName: true});
+
+    cy.log("Cannot add group with -, _ or space as first letter");
+    cy.apiGroupAdd("gaGroupAdmin"," ABC",true,HTTP_Unprocessable,{useRawGroupName: true});
+    cy.apiGroupAdd("gaGroupAdmin","-ABC",true,HTTP_Unprocessable,{useRawGroupName: true});
+    cy.apiGroupAdd("gaGroupAdmin","_ABC",true,HTTP_Unprocessable,{useRawGroupName: true});
+
+    cy.log("Can add group with -, _ or space as subsequent letter");
+    cy.apiGroupAdd("gaGroupAdmin","A B-C_D",true,HTTP_OK200);
+  });
+
+});
+

--- a/integration-tests/cypress/integration/api/groups/groups_add_get.ts
+++ b/integration-tests/cypress/integration/api/groups/groups_add_get.ts
@@ -1,6 +1,11 @@
 /// <reference path="../../../support/index.d.ts" />
 
-import { ApiGroupReturned, ApiGroupUserRelation, ApiDeviceIdAndName, ApiGroupUser } from "../../../commands/types";
+import {
+  ApiGroupReturned,
+  ApiGroupUserRelation,
+  ApiDeviceIdAndName,
+  ApiGroupUser,
+} from "../../../commands/types";
 import { getTestName } from "../../../commands/names";
 import { getCreds } from "../../../commands/server";
 
@@ -8,45 +13,87 @@ import { HTTP_OK200 } from "../../../commands/constants";
 import { HTTP_Unprocessable } from "../../../commands/constants";
 import { HTTP_Forbidden } from "../../../commands/constants";
 
-const ADMIN=true;
-const NOT_ADMIN=false;
-let expectedGroup:ApiGroupReturned;
-let expectedGroupAdminUser:ApiGroupUserRelation;
-let expectedGroupAdminGroupUser:ApiGroupUser;
-let expectedGroupMemberUser:ApiGroupUserRelation;
-let expectedGroupMemberGroupUser:ApiGroupUser;
-let expectedDevice:ApiDeviceIdAndName;
-let expectedDevice1b:ApiDeviceIdAndName;
-const EXCLUDE_CREATED_UPDATED_AT=["[].Users[].GroupUsers.createdAt","[].Users[].GroupUsers.updatedAt"];
+const ADMIN = true;
+const NOT_ADMIN = false;
+let expectedGroup: ApiGroupReturned;
+let expectedGroupAdminUser: ApiGroupUserRelation;
+let expectedGroupAdminGroupUser: ApiGroupUser;
+let expectedGroupMemberUser: ApiGroupUserRelation;
+let expectedGroupMemberGroupUser: ApiGroupUser;
+let expectedDevice: ApiDeviceIdAndName;
+let expectedDevice1b: ApiDeviceIdAndName;
+const EXCLUDE_CREATED_UPDATED_AT = [
+  "[].Users[].GroupUsers.createdAt",
+  "[].Users[].GroupUsers.updatedAt",
+];
 
 describe("Groups - add, get group", () => {
-
   before(() => {
     //admin user, group and device
-    cy.testCreateUserGroupAndDevice("gaGroupAdmin", "gaGroup", "gaCamera").then(() => {
-        expectedGroup={id:getCreds("gaGroup").id,groupname: getTestName("gaGroup"), 
-		Users: [],
-		Devices: [],
-		GroupUsers: []
-	};
-	expectedDevice={id: getCreds("gaCamera").id, devicename: getTestName("gaCamera")}
-	expectedGroupAdminUser={id: getCreds("gaGroupAdmin").id, username: getTestName("gaGroupAdmin"), GroupUsers: 
-          {admin: true, createdAt:"", updatedAt:"", GroupId: getCreds("gaGroup").id, UserId: getCreds("gaGroupAdmin").id}};
-        expectedGroupAdminGroupUser={id: getCreds("gaGroupAdmin").id, username: getTestName("gaGroupAdmin"), isAdmin:true};
-
-    });
+    cy.testCreateUserGroupAndDevice("gaGroupAdmin", "gaGroup", "gaCamera").then(
+      () => {
+        expectedGroup = {
+          id: getCreds("gaGroup").id,
+          groupname: getTestName("gaGroup"),
+          Users: [],
+          Devices: [],
+          GroupUsers: [],
+        };
+        expectedDevice = {
+          id: getCreds("gaCamera").id,
+          devicename: getTestName("gaCamera"),
+        };
+        expectedGroupAdminUser = {
+          id: getCreds("gaGroupAdmin").id,
+          username: getTestName("gaGroupAdmin"),
+          GroupUsers: {
+            admin: true,
+            createdAt: "",
+            updatedAt: "",
+            GroupId: getCreds("gaGroup").id,
+            UserId: getCreds("gaGroupAdmin").id,
+          },
+        };
+        expectedGroupAdminGroupUser = {
+          id: getCreds("gaGroupAdmin").id,
+          username: getTestName("gaGroupAdmin"),
+          isAdmin: true,
+        };
+      }
+    );
 
     //2nd device in this group
-    cy.apiDeviceAdd("gaCamera1b","gaGroup").then(() => {
-      expectedDevice1b={id: getCreds("gaCamera1b").id, devicename: getTestName("gaCamera1b")};
+    cy.apiDeviceAdd("gaCamera1b", "gaGroup").then(() => {
+      expectedDevice1b = {
+        id: getCreds("gaCamera1b").id,
+        devicename: getTestName("gaCamera1b"),
+      };
     });
 
     //group member for this group
     cy.apiUserAdd("gaGroupMember");
-    cy.apiGroupUserAdd("gaGroupAdmin", "gaGroupMember", "gaGroup", NOT_ADMIN).then(() => {
-      expectedGroupMemberUser={id: getCreds("gaGroupMember").id, username: getTestName("gaGroupMember"), GroupUsers:
-            {admin: false, createdAt:"", updatedAt:"", GroupId: getCreds("gaGroup").id, UserId: getCreds("gaGroupMember").id}};
-      expectedGroupMemberGroupUser={id: getCreds("gaGroupMember").id, username: getTestName("gaGroupMember"), isAdmin:false};
+    cy.apiGroupUserAdd(
+      "gaGroupAdmin",
+      "gaGroupMember",
+      "gaGroup",
+      NOT_ADMIN
+    ).then(() => {
+      expectedGroupMemberUser = {
+        id: getCreds("gaGroupMember").id,
+        username: getTestName("gaGroupMember"),
+        GroupUsers: {
+          admin: false,
+          createdAt: "",
+          updatedAt: "",
+          GroupId: getCreds("gaGroup").id,
+          UserId: getCreds("gaGroupMember").id,
+        },
+      };
+      expectedGroupMemberGroupUser = {
+        id: getCreds("gaGroupMember").id,
+        username: getTestName("gaGroupMember"),
+        isAdmin: false,
+      };
     });
 
     //device admin for 1st device
@@ -59,97 +106,165 @@ describe("Groups - add, get group", () => {
   });
 
   it("Can add a new group", () => {
-    let expectedTestGroup:ApiGroupReturned;
+    let expectedTestGroup: ApiGroupReturned;
     cy.log("Create a new group");
-    cy.apiGroupAdd("gaTestUser","gaTestGroup1",true).then(() => {
-	let expectedTestGroupUser={id: getCreds("gaTestUser").id, username: getTestName("gaTestUser"), GroupUsers: 
-          {admin: true, createdAt:"", updatedAt:"", GroupId: getCreds("gaTestGroup1").id, UserId: getCreds("gaTestUser").id}};
-        let expectedTestGroupGroupUser={id: getCreds("gaTestUser").id, username: getTestName("gaTestUser"), isAdmin:true};
-        expectedTestGroup={id:getCreds("gaTestGroup1").id,groupname: getTestName("gaTestGroup1"), 
-		Users: [expectedTestGroupUser],
-		Devices: [],
-		GroupUsers: [expectedTestGroupGroupUser]
-	};
+    cy.apiGroupAdd("gaTestUser", "gaTestGroup1", true).then(() => {
+      const expectedTestGroupUser = {
+        id: getCreds("gaTestUser").id,
+        username: getTestName("gaTestUser"),
+        GroupUsers: {
+          admin: true,
+          createdAt: "",
+          updatedAt: "",
+          GroupId: getCreds("gaTestGroup1").id,
+          UserId: getCreds("gaTestUser").id,
+        },
+      };
+      const expectedTestGroupGroupUser = {
+        id: getCreds("gaTestUser").id,
+        username: getTestName("gaTestUser"),
+        isAdmin: true,
+      };
+      expectedTestGroup = {
+        id: getCreds("gaTestGroup1").id,
+        groupname: getTestName("gaTestGroup1"),
+        Users: [expectedTestGroupUser],
+        Devices: [],
+        GroupUsers: [expectedTestGroupGroupUser],
+      };
 
-        cy.log("Group creator can view the created group");
-	//group query
-        cy.apiGroupCheck("gaTestUser", "gaTestGroup1", [expectedTestGroup], EXCLUDE_CREATED_UPDATED_AT);
+      cy.log("Group creator can view the created group");
+      //group query
+      cy.apiGroupCheck(
+        "gaTestUser",
+        "gaTestGroup1",
+        [expectedTestGroup],
+        EXCLUDE_CREATED_UPDATED_AT
+      );
     });
   });
 
   it("Admin and member can view group's devices and users", () => {
-     expectedGroup.Devices=[expectedDevice, expectedDevice1b];
-     expectedGroup.GroupUsers=[expectedGroupAdminGroupUser, expectedGroupMemberGroupUser];
-     let expectedGroup2=JSON.parse(JSON.stringify(expectedGroup));
+    expectedGroup.Devices = [expectedDevice, expectedDevice1b];
+    expectedGroup.GroupUsers = [
+      expectedGroupAdminGroupUser,
+      expectedGroupMemberGroupUser,
+    ];
+    const expectedGroup2 = JSON.parse(JSON.stringify(expectedGroup));
 
-     cy.log("Check admin can view group, devices and user");
-     expectedGroup.Users=[expectedGroupAdminUser];
-     cy.apiGroupCheck("gaGroupAdmin", "gaGroup", [expectedGroup], EXCLUDE_CREATED_UPDATED_AT);
+    cy.log("Check admin can view group, devices and user");
+    expectedGroup.Users = [expectedGroupAdminUser];
+    cy.apiGroupCheck(
+      "gaGroupAdmin",
+      "gaGroup",
+      [expectedGroup],
+      EXCLUDE_CREATED_UPDATED_AT
+    );
 
-     cy.log("Check member can view group, devices and user");
-     expectedGroup2.Users=[expectedGroupMemberUser];
-     cy.apiGroupCheck("gaGroupMember", "gaGroup", [expectedGroup2], EXCLUDE_CREATED_UPDATED_AT);
+    cy.log("Check member can view group, devices and user");
+    expectedGroup2.Users = [expectedGroupMemberUser];
+    cy.apiGroupCheck(
+      "gaGroupMember",
+      "gaGroup",
+      [expectedGroup2],
+      EXCLUDE_CREATED_UPDATED_AT
+    );
   });
 
-
   it("Can query using group id", () => {
-    expectedGroup.Devices=[expectedDevice, expectedDevice1b];
-    expectedGroup.GroupUsers=[expectedGroupAdminGroupUser, expectedGroupMemberGroupUser];
-    expectedGroup.Users=[expectedGroupAdminUser];
+    expectedGroup.Devices = [expectedDevice, expectedDevice1b];
+    expectedGroup.GroupUsers = [
+      expectedGroupAdminGroupUser,
+      expectedGroupMemberGroupUser,
+    ];
+    expectedGroup.Users = [expectedGroupAdminUser];
     //Query using group id
-    cy.apiGroupCheck("gaGroupAdmin", getCreds("gaGroup").id.toString(), [expectedGroup], EXCLUDE_CREATED_UPDATED_AT,HTTP_OK200, {useRawGroupName: true});
-
+    cy.apiGroupCheck(
+      "gaGroupAdmin",
+      getCreds("gaGroup").id.toString(),
+      [expectedGroup],
+      EXCLUDE_CREATED_UPDATED_AT,
+      HTTP_OK200,
+      { useRawGroupName: true }
+    );
   });
 
   it("Non member cannot query", () => {
     //TODO: This behaviou ris inconsistent with other API endpoints.  Most return 403 to requests the user has
-    // no permission for. Thuis one returns 200 and an empty result. Issue 
+    // no permission for. Thuis one returns 200 and an empty result. Issue
     cy.log("Valid user with no access to this group");
-//    cy.apiGroupCheck("gaTestUser", "gaGroup", [], [], HTTP_Forbidden);   
-    cy.apiGroupCheck("gaTestUser", "gaGroup", [], [], HTTP_OK200);   
+    //    cy.apiGroupCheck("gaTestUser", "gaGroup", [], [], HTTP_Forbidden);
+    cy.apiGroupCheck("gaTestUser", "gaGroup", [], [], HTTP_OK200);
 
     cy.log("Device admin with no group-level permisssions");
-//    cy.apiGroupCheck("gaDeviceAdmin", "gaGroup", [], [], HTTP_Forbidden);
+    //    cy.apiGroupCheck("gaDeviceAdmin", "gaGroup", [], [], HTTP_Forbidden);
     cy.apiGroupCheck("gaDeviceAdmin", "gaGroup", [], [], HTTP_OK200);
 
     cy.log("Valid user with no access to this group using groupId");
-//    cy.apiGroupCheck("gaTestUser", getCreds("gaGroup").id.toString(), [], [], HTTP_Forbidden, {useRawGroupName: true});
-    cy.apiGroupCheck("gaTestUser", getCreds("gaGroup").id.toString(), [], [], HTTP_OK200, {useRawGroupName: true});
+    //    cy.apiGroupCheck("gaTestUser", getCreds("gaGroup").id.toString(), [], [], HTTP_Forbidden, {useRawGroupName: true});
+    cy.apiGroupCheck(
+      "gaTestUser",
+      getCreds("gaGroup").id.toString(),
+      [],
+      [],
+      HTTP_OK200,
+      { useRawGroupName: true }
+    );
   });
 
   it("Query nonexistant group handled correctly", () => {
-    cy.apiGroupCheck("gaGroupAdmin", "IDontExist", [], [], HTTP_Unprocessable, {useRawGroupName: true});
+    cy.apiGroupCheck("gaGroupAdmin", "IDontExist", [], [], HTTP_Unprocessable, {
+      useRawGroupName: true,
+    });
 
-    cy.apiGroupCheck("gaGroupAdmin", "9999999", [], [], HTTP_Unprocessable, {useRawGroupName: true});
+    cy.apiGroupCheck("gaGroupAdmin", "9999999", [], [], HTTP_Unprocessable, {
+      useRawGroupName: true,
+    });
   });
 
   it("Cannot create group with same name (even with different case)", () => {
     cy.log("Add duplicate group (same user)");
-    cy.apiGroupAdd("gaGroupAdmin","gaGroup",true,HTTP_Unprocessable);
+    cy.apiGroupAdd("gaGroupAdmin", "gaGroup", true, HTTP_Unprocessable);
     cy.log("Add duplicate group (different user)");
-    cy.apiGroupAdd("gaTestUser","gaGroup",true,HTTP_Unprocessable);
+    cy.apiGroupAdd("gaTestUser", "gaGroup", true, HTTP_Unprocessable);
     cy.log("Add duplicate group (different case)");
-    cy.apiGroupAdd("gaGroupAdmin","GAGROUP",true,HTTP_Unprocessable);
+    cy.apiGroupAdd("gaGroupAdmin", "GAGROUP", true, HTTP_Unprocessable);
   });
   it("Invalid group names rejected", () => {
     cy.log("Cannot add group with no letters");
-    cy.apiGroupAdd("gaGroupAdmin","",true,HTTP_Unprocessable,{useRawGroupName: true});
-    cy.apiGroupAdd("gaGroupAdmin","1234",true,HTTP_Unprocessable,{useRawGroupName: true});
+    cy.apiGroupAdd("gaGroupAdmin", "", true, HTTP_Unprocessable, {
+      useRawGroupName: true,
+    });
+    cy.apiGroupAdd("gaGroupAdmin", "1234", true, HTTP_Unprocessable, {
+      useRawGroupName: true,
+    });
 
     cy.log("Cannot add group with other non-alphanumeric characters");
-    cy.apiGroupAdd("gaGroupAdmin","ABC%",true,HTTP_Unprocessable,{useRawGroupName: true});
-    cy.apiGroupAdd("gaGroupAdmin","ABC&",true,HTTP_Unprocessable,{useRawGroupName: true});
-    cy.apiGroupAdd("gaGroupAdmin","ABC<",true,HTTP_Unprocessable,{useRawGroupName: true});
-    cy.apiGroupAdd("gaGroupAdmin","ABC>",true,HTTP_Unprocessable,{useRawGroupName: true});
+    cy.apiGroupAdd("gaGroupAdmin", "ABC%", true, HTTP_Unprocessable, {
+      useRawGroupName: true,
+    });
+    cy.apiGroupAdd("gaGroupAdmin", "ABC&", true, HTTP_Unprocessable, {
+      useRawGroupName: true,
+    });
+    cy.apiGroupAdd("gaGroupAdmin", "ABC<", true, HTTP_Unprocessable, {
+      useRawGroupName: true,
+    });
+    cy.apiGroupAdd("gaGroupAdmin", "ABC>", true, HTTP_Unprocessable, {
+      useRawGroupName: true,
+    });
 
     cy.log("Cannot add group with -, _ or space as first letter");
-    cy.apiGroupAdd("gaGroupAdmin"," ABC",true,HTTP_Unprocessable,{useRawGroupName: true});
-    cy.apiGroupAdd("gaGroupAdmin","-ABC",true,HTTP_Unprocessable,{useRawGroupName: true});
-    cy.apiGroupAdd("gaGroupAdmin","_ABC",true,HTTP_Unprocessable,{useRawGroupName: true});
+    cy.apiGroupAdd("gaGroupAdmin", " ABC", true, HTTP_Unprocessable, {
+      useRawGroupName: true,
+    });
+    cy.apiGroupAdd("gaGroupAdmin", "-ABC", true, HTTP_Unprocessable, {
+      useRawGroupName: true,
+    });
+    cy.apiGroupAdd("gaGroupAdmin", "_ABC", true, HTTP_Unprocessable, {
+      useRawGroupName: true,
+    });
 
     cy.log("Can add group with -, _ or space as subsequent letter");
-    cy.apiGroupAdd("gaGroupAdmin","A B-C_D",true,HTTP_OK200);
+    cy.apiGroupAdd("gaGroupAdmin", "A B-C_D", true, HTTP_OK200);
   });
-
 });
-

--- a/integration-tests/cypress/integration/api/groups/groups_devices.ts
+++ b/integration-tests/cypress/integration/api/groups/groups_devices.ts
@@ -1,0 +1,121 @@
+/// <reference path="../../../support/index.d.ts" />
+
+import { ApiGroupsDevice, ApiDevicesDevice } from "../../../commands/types";
+import { getTestName } from "../../../commands/names";
+import { getCreds } from "../../../commands/server";
+
+import { HTTP_OK200 } from "../../../commands/constants";
+import { HTTP_Forbidden } from "../../../commands/constants";
+import { HTTP_Unprocessable } from "../../../commands/constants";
+
+const ADMIN=true;
+const NOT_ADMIN=false;
+let expectedDevice:ApiGroupsDevice;
+let expectedDevice1b:ApiGroupsDevice;
+
+describe("Groups - get devices for group", () => {
+
+  before(() => {
+    //admin user, group and device
+    cy.apiCreateUserGroupAndDevice("gdGroupAdmin", "gdGroup", "gdCamera").then(() => {
+      expectedDevice={id: getCreds("gdCamera").id, deviceName: getTestName("gdCamera")}
+    });
+
+    //2nd group
+    cy.apiGroupAdd("gdGroupAdmin", "gdGroup2").then(() => {
+    });
+
+    //2nd device in first group
+    cy.apiCreateDevice("gdCamera1b","gdGroup").then(() => {
+      expectedDevice1b={id: getCreds("gdCamera1b").id, deviceName: getTestName("gdCamera1b")};
+    });
+
+    //group member for this group
+    cy.apiCreateUser("gdGroupMember");
+    cy.apiGroupUserAdd("gdGroupAdmin", "gdGroupMember", "gdGroup", NOT_ADMIN);
+
+    //device admin for 1st device
+    cy.apiCreateUser("gdDeviceAdmin");
+    cy.apiAddUserToDevice("gdGroupAdmin", "gdDeviceAdmin", "gdCamera", ADMIN);
+
+    // test users
+    cy.apiCreateUser("gdTestUser");
+  });
+
+  it("Admin and member can view group's devices", () => {
+     cy.log("Check admin can view group's device");
+     cy.apiGroupsDevicesCheck("gdGroupAdmin", "gdGroup", [expectedDevice, expectedDevice1b]);
+
+     cy.log("Check member can view group's devices");
+     cy.apiGroupsDevicesCheck("gdGroupMember", "gdGroup", [expectedDevice, expectedDevice1b]);
+  });
+
+  it("Non group members cannot view devices", () => {
+     cy.log("Check device-only user cannot view groups devies");
+     cy.apiGroupsDevicesCheck("gdDeviceAdmin", "gdGroup", [], [], HTTP_Forbidden);
+
+     cy.log("Check unrelated user cannot view group's devices");
+     cy.apiGroupsDevicesCheck("gdTestUser", "gdGroup", [], [], HTTP_Forbidden);
+  });
+
+  it("Can query using group id", () => {
+     cy.log("Check admin can view group's device");
+     cy.apiGroupsDevicesCheck("gdGroupAdmin", getCreds("gdGroup").id, [expectedDevice, expectedDevice1b], [], HTTP_OK200, {useRawGroupName: true});
+
+     cy.log("Check member can view group's devices");
+     cy.apiGroupsDevicesCheck("gdGroupMember", getCreds("gdGroup").id, [expectedDevice, expectedDevice1b], [], HTTP_OK200, {useRawGroupName: true} );
+
+  });
+
+  it("Lists only active devices", () => {
+    let expectedDevice4a:ApiDevicesDevice;
+    let expectedDevice4b:ApiDevicesDevice;
+    let expectedGroupDevice4b:ApiGroupsDevice;
+
+    cy.log("Register a camera for the test");
+    cy.apiCreateUserGroup("gdUser4", "gdGroup4");
+    cy.apiCreateDevice("gdCam4a", "gdGroup4").then(() => {
+      expectedDevice4a = {
+         id: getCreds("gdCam4a").id,
+         devicename: getTestName("gdCam4a"),
+         active: false,
+         Users: [],
+       };
+
+    });
+  
+    cy.log("Reregister the camera, making the old camera inactive");
+    cy.apiDeviceReregister("gdCam4a", "gdCam4b", "gdGroup4").then(() => {
+      expectedGroupDevice4b = {
+        id: getCreds("gdCam4b").id,
+        deviceName: getTestName("gdCam4b"),
+      };
+      expectedDevice4b = {
+       id: getCreds("gdCam4b").id,
+       devicename: getTestName("gdCam4b"),
+       active: true,
+       Users: [],
+     };
+
+      cy.log("Verify device query shows both old device as inactive (and new one as active)");
+      cy.apiCheckDevices("gdUser4", [expectedDevice4a, expectedDevice4b], {
+        onlyActive: false,
+      });
+
+      cy.log("But verify groups query only shows active device");
+      cy.apiGroupsDevicesCheck("gdUser4", "gdGroup4", [expectedGroupDevice4b]);
+    });
+
+  });
+
+  it("Handles non-existant group correctly", () => {
+    cy.apiGroupsDevicesCheck("gdUser4", "IDoNotExist", [], [], HTTP_Unprocessable, {useRawGroupName: true});
+  });
+
+  it("Handles group with no devices correctly", () => {
+    cy.apiCreateUserGroup("gdUser6", "gdGroup6").then (() => {
+      cy.apiGroupsDevicesCheck("gdUser6", "gdGroup6", []); 
+    });;
+  });
+
+});

--- a/integration-tests/cypress/integration/api/groups/groups_devices.ts
+++ b/integration-tests/cypress/integration/api/groups/groups_devices.ts
@@ -50,10 +50,16 @@ describe("Groups - get devices for group", () => {
 
   it("Admin and member can view group's devices", () => {
     cy.log("Check admin can view group's device");
-    cy.apiGroupDevicesCheck("gdGroupAdmin", "gdGroup", [ expectedDevice, expectedDevice1b ]);
+    cy.apiGroupDevicesCheck("gdGroupAdmin", "gdGroup", [
+      expectedDevice,
+      expectedDevice1b,
+    ]);
 
     cy.log("Check member can view group's devices");
-    cy.apiGroupDevicesCheck("gdGroupMember", "gdGroup", [ expectedDevice, expectedDevice1b ]);
+    cy.apiGroupDevicesCheck("gdGroupMember", "gdGroup", [
+      expectedDevice,
+      expectedDevice1b,
+    ]);
   });
 
   it("Non group members cannot view devices", () => {

--- a/integration-tests/cypress/integration/api/groups/groups_devices.ts
+++ b/integration-tests/cypress/integration/api/groups/groups_devices.ts
@@ -50,16 +50,10 @@ describe("Groups - get devices for group", () => {
 
   it("Admin and member can view group's devices", () => {
     cy.log("Check admin can view group's device");
-    cy.apiGroupDevicesCheck("gdGroupAdmin", "gdGroup", [
-      expectedDevice,
-      expectedDevice1b,
-    ]);
+    cy.apiGroupDevicesCheck("gdGroupAdmin", "gdGroup", [ expectedDevice, expectedDevice1b ]);
 
     cy.log("Check member can view group's devices");
-    cy.apiGroupDevicesCheck("gdGroupMember", "gdGroup", [
-      expectedDevice,
-      expectedDevice1b,
-    ]);
+    cy.apiGroupDevicesCheck("gdGroupMember", "gdGroup", [ expectedDevice, expectedDevice1b ]);
   });
 
   it("Non group members cannot view devices", () => {

--- a/integration-tests/cypress/integration/api/groups/groups_devices.ts
+++ b/integration-tests/cypress/integration/api/groups/groups_devices.ts
@@ -8,26 +8,32 @@ import { HTTP_OK200 } from "../../../commands/constants";
 import { HTTP_Forbidden } from "../../../commands/constants";
 import { HTTP_Unprocessable } from "../../../commands/constants";
 
-const ADMIN=true;
-const NOT_ADMIN=false;
-let expectedDevice:ApiGroupsDevice;
-let expectedDevice1b:ApiGroupsDevice;
+const ADMIN = true;
+const NOT_ADMIN = false;
+let expectedDevice: ApiGroupsDevice;
+let expectedDevice1b: ApiGroupsDevice;
 
 describe("Groups - get devices for group", () => {
-
   before(() => {
     //admin user, group and device
-    cy.testCreateUserGroupAndDevice("gdGroupAdmin", "gdGroup", "gdCamera").then(() => {
-      expectedDevice={id: getCreds("gdCamera").id, deviceName: getTestName("gdCamera")}
-    });
+    cy.testCreateUserGroupAndDevice("gdGroupAdmin", "gdGroup", "gdCamera").then(
+      () => {
+        expectedDevice = {
+          id: getCreds("gdCamera").id,
+          deviceName: getTestName("gdCamera"),
+        };
+      }
+    );
 
     //2nd group
-    cy.apiGroupAdd("gdGroupAdmin", "gdGroup2").then(() => {
-    });
+    cy.apiGroupAdd("gdGroupAdmin", "gdGroup2").then(() => {});
 
     //2nd device in first group
-    cy.apiDeviceAdd("gdCamera1b","gdGroup").then(() => {
-      expectedDevice1b={id: getCreds("gdCamera1b").id, deviceName: getTestName("gdCamera1b")};
+    cy.apiDeviceAdd("gdCamera1b", "gdGroup").then(() => {
+      expectedDevice1b = {
+        id: getCreds("gdCamera1b").id,
+        deviceName: getTestName("gdCamera1b"),
+      };
     });
 
     //group member for this group
@@ -43,47 +49,65 @@ describe("Groups - get devices for group", () => {
   });
 
   it("Admin and member can view group's devices", () => {
-     cy.log("Check admin can view group's device");
-     cy.apiGroupDevicesCheck("gdGroupAdmin", "gdGroup", [expectedDevice, expectedDevice1b]);
+    cy.log("Check admin can view group's device");
+    cy.apiGroupDevicesCheck("gdGroupAdmin", "gdGroup", [
+      expectedDevice,
+      expectedDevice1b,
+    ]);
 
-     cy.log("Check member can view group's devices");
-     cy.apiGroupDevicesCheck("gdGroupMember", "gdGroup", [expectedDevice, expectedDevice1b]);
+    cy.log("Check member can view group's devices");
+    cy.apiGroupDevicesCheck("gdGroupMember", "gdGroup", [
+      expectedDevice,
+      expectedDevice1b,
+    ]);
   });
 
   it("Non group members cannot view devices", () => {
-     cy.log("Check device-only user cannot view groups devies");
-     cy.apiGroupDevicesCheck("gdDeviceAdmin", "gdGroup", [], [], HTTP_Forbidden);
+    cy.log("Check device-only user cannot view groups devies");
+    cy.apiGroupDevicesCheck("gdDeviceAdmin", "gdGroup", [], [], HTTP_Forbidden);
 
-     cy.log("Check unrelated user cannot view group's devices");
-     cy.apiGroupDevicesCheck("gdTestUser", "gdGroup", [], [], HTTP_Forbidden);
+    cy.log("Check unrelated user cannot view group's devices");
+    cy.apiGroupDevicesCheck("gdTestUser", "gdGroup", [], [], HTTP_Forbidden);
   });
 
   it("Can query using group id", () => {
-     cy.log("Check admin can view group's device");
-     cy.apiGroupDevicesCheck("gdGroupAdmin", getCreds("gdGroup").id, [expectedDevice, expectedDevice1b], [], HTTP_OK200, {useRawGroupName: true});
+    cy.log("Check admin can view group's device");
+    cy.apiGroupDevicesCheck(
+      "gdGroupAdmin",
+      getCreds("gdGroup").id,
+      [expectedDevice, expectedDevice1b],
+      [],
+      HTTP_OK200,
+      { useRawGroupName: true }
+    );
 
-     cy.log("Check member can view group's devices");
-     cy.apiGroupDevicesCheck("gdGroupMember", getCreds("gdGroup").id, [expectedDevice, expectedDevice1b], [], HTTP_OK200, {useRawGroupName: true} );
-
+    cy.log("Check member can view group's devices");
+    cy.apiGroupDevicesCheck(
+      "gdGroupMember",
+      getCreds("gdGroup").id,
+      [expectedDevice, expectedDevice1b],
+      [],
+      HTTP_OK200,
+      { useRawGroupName: true }
+    );
   });
 
   it("Lists only active devices", () => {
-    let expectedDevice4a:ApiDevicesDevice;
-    let expectedDevice4b:ApiDevicesDevice;
-    let expectedGroupDevice4b:ApiGroupsDevice;
+    let expectedDevice4a: ApiDevicesDevice;
+    let expectedDevice4b: ApiDevicesDevice;
+    let expectedGroupDevice4b: ApiGroupsDevice;
 
     cy.log("Register a camera for the test");
     cy.testCreateUserAndGroup("gdUser4", "gdGroup4");
     cy.apiDeviceAdd("gdCam4a", "gdGroup4").then(() => {
       expectedDevice4a = {
-         id: getCreds("gdCam4a").id,
-         devicename: getTestName("gdCam4a"),
-         active: false,
-         Users: [],
-       };
-
+        id: getCreds("gdCam4a").id,
+        devicename: getTestName("gdCam4a"),
+        active: false,
+        Users: [],
+      };
     });
-  
+
     cy.log("Reregister the camera, making the old camera inactive");
     cy.apiDeviceReregister("gdCam4a", "gdCam4b", "gdGroup4").then(() => {
       expectedGroupDevice4b = {
@@ -91,13 +115,15 @@ describe("Groups - get devices for group", () => {
         deviceName: getTestName("gdCam4b"),
       };
       expectedDevice4b = {
-       id: getCreds("gdCam4b").id,
-       devicename: getTestName("gdCam4b"),
-       active: true,
-       Users: [],
-     };
+        id: getCreds("gdCam4b").id,
+        devicename: getTestName("gdCam4b"),
+        active: true,
+        Users: [],
+      };
 
-      cy.log("Verify device query shows both old device as inactive (and new one as active)");
+      cy.log(
+        "Verify device query shows both old device as inactive (and new one as active)"
+      );
       cy.apiDevicesCheck("gdUser4", [expectedDevice4a, expectedDevice4b], {
         onlyActive: false,
       });
@@ -105,17 +131,22 @@ describe("Groups - get devices for group", () => {
       cy.log("But verify groups query only shows active device");
       cy.apiGroupDevicesCheck("gdUser4", "gdGroup4", [expectedGroupDevice4b]);
     });
-
   });
 
   it("Handles non-existant group correctly", () => {
-    cy.apiGroupDevicesCheck("gdUser4", "IDoNotExist", [], [], HTTP_Unprocessable, {useRawGroupName: true});
+    cy.apiGroupDevicesCheck(
+      "gdUser4",
+      "IDoNotExist",
+      [],
+      [],
+      HTTP_Unprocessable,
+      { useRawGroupName: true }
+    );
   });
 
   it("Handles group with no devices correctly", () => {
-    cy.testCreateUserAndGroup("gdUser6", "gdGroup6").then (() => {
-      cy.apiGroupDevicesCheck("gdUser6", "gdGroup6", []); 
-    });;
+    cy.testCreateUserAndGroup("gdUser6", "gdGroup6").then(() => {
+      cy.apiGroupDevicesCheck("gdUser6", "gdGroup6", []);
+    });
   });
-
 });

--- a/integration-tests/cypress/integration/api/groups/groups_devices.ts
+++ b/integration-tests/cypress/integration/api/groups/groups_devices.ts
@@ -17,7 +17,7 @@ describe("Groups - get devices for group", () => {
 
   before(() => {
     //admin user, group and device
-    cy.apiCreateUserGroupAndDevice("gdGroupAdmin", "gdGroup", "gdCamera").then(() => {
+    cy.testCreateUserGroupAndDevice("gdGroupAdmin", "gdGroup", "gdCamera").then(() => {
       expectedDevice={id: getCreds("gdCamera").id, deviceName: getTestName("gdCamera")}
     });
 
@@ -26,44 +26,44 @@ describe("Groups - get devices for group", () => {
     });
 
     //2nd device in first group
-    cy.apiCreateDevice("gdCamera1b","gdGroup").then(() => {
+    cy.apiDeviceAdd("gdCamera1b","gdGroup").then(() => {
       expectedDevice1b={id: getCreds("gdCamera1b").id, deviceName: getTestName("gdCamera1b")};
     });
 
     //group member for this group
-    cy.apiCreateUser("gdGroupMember");
+    cy.apiUserAdd("gdGroupMember");
     cy.apiGroupUserAdd("gdGroupAdmin", "gdGroupMember", "gdGroup", NOT_ADMIN);
 
     //device admin for 1st device
-    cy.apiCreateUser("gdDeviceAdmin");
-    cy.apiAddUserToDevice("gdGroupAdmin", "gdDeviceAdmin", "gdCamera", ADMIN);
+    cy.apiUserAdd("gdDeviceAdmin");
+    cy.apiDeviceUserAdd("gdGroupAdmin", "gdDeviceAdmin", "gdCamera", ADMIN);
 
     // test users
-    cy.apiCreateUser("gdTestUser");
+    cy.apiUserAdd("gdTestUser");
   });
 
   it("Admin and member can view group's devices", () => {
      cy.log("Check admin can view group's device");
-     cy.apiGroupsDevicesCheck("gdGroupAdmin", "gdGroup", [expectedDevice, expectedDevice1b]);
+     cy.apiGroupDevicesCheck("gdGroupAdmin", "gdGroup", [expectedDevice, expectedDevice1b]);
 
      cy.log("Check member can view group's devices");
-     cy.apiGroupsDevicesCheck("gdGroupMember", "gdGroup", [expectedDevice, expectedDevice1b]);
+     cy.apiGroupDevicesCheck("gdGroupMember", "gdGroup", [expectedDevice, expectedDevice1b]);
   });
 
   it("Non group members cannot view devices", () => {
      cy.log("Check device-only user cannot view groups devies");
-     cy.apiGroupsDevicesCheck("gdDeviceAdmin", "gdGroup", [], [], HTTP_Forbidden);
+     cy.apiGroupDevicesCheck("gdDeviceAdmin", "gdGroup", [], [], HTTP_Forbidden);
 
      cy.log("Check unrelated user cannot view group's devices");
-     cy.apiGroupsDevicesCheck("gdTestUser", "gdGroup", [], [], HTTP_Forbidden);
+     cy.apiGroupDevicesCheck("gdTestUser", "gdGroup", [], [], HTTP_Forbidden);
   });
 
   it("Can query using group id", () => {
      cy.log("Check admin can view group's device");
-     cy.apiGroupsDevicesCheck("gdGroupAdmin", getCreds("gdGroup").id, [expectedDevice, expectedDevice1b], [], HTTP_OK200, {useRawGroupName: true});
+     cy.apiGroupDevicesCheck("gdGroupAdmin", getCreds("gdGroup").id, [expectedDevice, expectedDevice1b], [], HTTP_OK200, {useRawGroupName: true});
 
      cy.log("Check member can view group's devices");
-     cy.apiGroupsDevicesCheck("gdGroupMember", getCreds("gdGroup").id, [expectedDevice, expectedDevice1b], [], HTTP_OK200, {useRawGroupName: true} );
+     cy.apiGroupDevicesCheck("gdGroupMember", getCreds("gdGroup").id, [expectedDevice, expectedDevice1b], [], HTTP_OK200, {useRawGroupName: true} );
 
   });
 
@@ -73,8 +73,8 @@ describe("Groups - get devices for group", () => {
     let expectedGroupDevice4b:ApiGroupsDevice;
 
     cy.log("Register a camera for the test");
-    cy.apiCreateUserGroup("gdUser4", "gdGroup4");
-    cy.apiCreateDevice("gdCam4a", "gdGroup4").then(() => {
+    cy.testCreateUserAndGroup("gdUser4", "gdGroup4");
+    cy.apiDeviceAdd("gdCam4a", "gdGroup4").then(() => {
       expectedDevice4a = {
          id: getCreds("gdCam4a").id,
          devicename: getTestName("gdCam4a"),
@@ -98,23 +98,23 @@ describe("Groups - get devices for group", () => {
      };
 
       cy.log("Verify device query shows both old device as inactive (and new one as active)");
-      cy.apiCheckDevices("gdUser4", [expectedDevice4a, expectedDevice4b], {
+      cy.apiDevicesCheck("gdUser4", [expectedDevice4a, expectedDevice4b], {
         onlyActive: false,
       });
 
       cy.log("But verify groups query only shows active device");
-      cy.apiGroupsDevicesCheck("gdUser4", "gdGroup4", [expectedGroupDevice4b]);
+      cy.apiGroupDevicesCheck("gdUser4", "gdGroup4", [expectedGroupDevice4b]);
     });
 
   });
 
   it("Handles non-existant group correctly", () => {
-    cy.apiGroupsDevicesCheck("gdUser4", "IDoNotExist", [], [], HTTP_Unprocessable, {useRawGroupName: true});
+    cy.apiGroupDevicesCheck("gdUser4", "IDoNotExist", [], [], HTTP_Unprocessable, {useRawGroupName: true});
   });
 
   it("Handles group with no devices correctly", () => {
-    cy.apiCreateUserGroup("gdUser6", "gdGroup6").then (() => {
-      cy.apiGroupsDevicesCheck("gdUser6", "gdGroup6", []); 
+    cy.testCreateUserAndGroup("gdUser6", "gdGroup6").then (() => {
+      cy.apiGroupDevicesCheck("gdUser6", "gdGroup6", []); 
     });;
   });
 

--- a/integration-tests/cypress/integration/api/groups/groups_query.ts
+++ b/integration-tests/cypress/integration/api/groups/groups_query.ts
@@ -1,0 +1,160 @@
+/// <reference path="../../../support/index.d.ts" />
+
+import { ApiGroupReturned, ApiGroupUserRelation, ApiDeviceIdAndName, ApiGroupUser } from "../../../commands/types";
+import { getTestName } from "../../../commands/names";
+import { getCreds } from "../../../commands/server";
+
+import { HTTP_OK200 } from "../../../commands/constants";
+import { HTTP_Unprocessable } from "../../../commands/constants";
+
+const ADMIN=true;
+const NOT_ADMIN=false;
+let expectedGroup:ApiGroupReturned;
+let expectedGroup2:ApiGroupReturned;
+let expectedGroupAdminUser:ApiGroupUserRelation;
+let expectedGroupAdminGroupUser:ApiGroupUser;
+let expectedGroup2AdminUser:ApiGroupUserRelation;
+let expectedGroup2AdminGroupUser:ApiGroupUser;
+let expectedGroupMemberUser:ApiGroupUserRelation;
+let expectedGroupMemberGroupUser:ApiGroupUser;
+let expectedDevice:ApiDeviceIdAndName;
+let expectedDevice1b:ApiDeviceIdAndName;
+const EXCLUDE_CREATED_UPDATED_AT=["[].Users[].GroupUsers.createdAt","[].Users[].GroupUsers.updatedAt"];
+
+describe("Groups - query groups", () => {
+
+  before(() => {
+    //admin user, group and device
+    cy.apiCreateUserGroupAndDevice("gqGroupAdmin", "gqGroup", "gqCamera").then(() => {
+        expectedGroup={id:getCreds("gqGroup").id,groupname: getTestName("gqGroup"), 
+		Users: [],
+		Devices: [],
+		GroupUsers: []
+	};
+	expectedDevice={id: getCreds("gqCamera").id, devicename: getTestName("gqCamera")}
+	expectedGroupAdminUser={id: getCreds("gqGroupAdmin").id, username: getTestName("gqGroupAdmin"), GroupUsers: 
+          {admin: true, createdAt:"", updatedAt:"", GroupId: getCreds("gqGroup").id, UserId: getCreds("gqGroupAdmin").id}};
+        expectedGroupAdminGroupUser={id: getCreds("gqGroupAdmin").id, username: getTestName("gqGroupAdmin"), isAdmin:true};
+
+    });
+
+    //2nd group
+    cy.apiGroupAdd("gqGroupAdmin", "gqGroup2").then(() => {
+        expectedGroup2={id:getCreds("gqGroup2").id,groupname: getTestName("gqGroup2"), 
+		Users: [],
+		Devices: [],
+		GroupUsers: []
+	};
+	expectedGroup2AdminUser={id: getCreds("gqGroupAdmin").id, username: getTestName("gqGroupAdmin"), GroupUsers: 
+          {admin: true, createdAt:"", updatedAt:"", GroupId: getCreds("gqGroup2").id, UserId: getCreds("gqGroupAdmin").id}};
+        expectedGroup2AdminGroupUser={id: getCreds("gqGroupAdmin").id, username: getTestName("gqGroupAdmin"), isAdmin:true};
+    });
+
+    //2nd device in this group
+    cy.apiCreateDevice("gqCamera1b","gqGroup").then(() => {
+      expectedDevice1b={id: getCreds("gqCamera1b").id, devicename: getTestName("gqCamera1b")};
+    });
+
+    //group member for this group
+    cy.apiCreateUser("gqGroupMember");
+    cy.apiGroupUserAdd("gqGroupAdmin", "gqGroupMember", "gqGroup", NOT_ADMIN).then(() => {
+      expectedGroupMemberUser={id: getCreds("gqGroupMember").id, username: getTestName("gqGroupMember"), GroupUsers:
+            {admin: false, createdAt:"", updatedAt:"", GroupId: getCreds("gqGroup").id, UserId: getCreds("gqGroupMember").id}};
+      expectedGroupMemberGroupUser={id: getCreds("gqGroupMember").id, username: getTestName("gqGroupMember"), isAdmin:false};
+    });
+
+    //device admin for 1st device
+    cy.apiCreateUser("gqDeviceAdmin");
+    cy.apiAddUserToDevice("gqGroupAdmin", "gqDeviceAdmin", "gqCamera", ADMIN);
+
+    // test users
+    cy.apiCreateUser("gqTestUser");
+  });
+
+  it("Admin and member can view group's devices and users", () => {
+     expectedGroup.Devices=[expectedDevice, expectedDevice1b];
+     expectedGroup.GroupUsers=[expectedGroupAdminGroupUser, expectedGroupMemberGroupUser];
+     let expectedGroup2=JSON.parse(JSON.stringify(expectedGroup));
+
+     cy.log("Check admin can view group, devices and user");
+     expectedGroup.Users=[expectedGroupAdminUser];
+     cy.apiGroupsCheck("gqGroupAdmin", {"groupname":getTestName("gqGroup")}, [expectedGroup], EXCLUDE_CREATED_UPDATED_AT);
+
+     cy.log("Check member can view group, devices and user");
+     expectedGroup2.Users=[expectedGroupMemberUser];
+     cy.apiGroupsCheck("gqGroupMember", {"groupname":getTestName("gqGroup")}, [expectedGroup2], EXCLUDE_CREATED_UPDATED_AT);
+  });
+
+
+  it("Can query using group id", () => {
+    expectedGroup.Devices=[expectedDevice, expectedDevice1b];
+    expectedGroup.GroupUsers=[expectedGroupAdminGroupUser, expectedGroupMemberGroupUser];
+    expectedGroup.Users=[expectedGroupAdminUser];
+    //Query using group id
+    cy.apiGroupsCheck("gqGroupAdmin", {"id":getCreds("gqGroup").id}, [expectedGroup], EXCLUDE_CREATED_UPDATED_AT,HTTP_OK200);
+  });
+
+  it("Can query using other operators (>=, <) and createdAt", () => {
+    // create a new group with a later timestamp
+    const timestamp = new Date().toISOString();
+    let expectedGroup3:ApiGroupReturned;
+    cy.apiCreateUserGroupAndDevice("gqGroupAdmin3", "gqGroup3", "gqCamera3").then(() => {
+      expectedGroup3={id:getCreds("gqGroup3").id,groupname: getTestName("gqGroup3"),
+        Users: [{id: getCreds("gqGroupAdmin3").id, username: getTestName("gqGroupAdmin3"), GroupUsers:
+          {admin: true, createdAt:"", updatedAt:"", GroupId: getCreds("gqGroup3").id, UserId: getCreds("gqGroupAdmin3").id}}],
+        Devices: [{id: getCreds("gqCamera3").id, devicename: getTestName("gqCamera3")}],
+        GroupUsers: [{id: getCreds("gqGroupAdmin3").id, username: getTestName("gqGroupAdmin3"), isAdmin:true}]
+      };
+
+      cy.log("Query using greater than or equal to createdAt - should be included in results");
+      cy.apiGroupsCheck("gqGroupAdmin3", {"createdAt":{$gte:timestamp}}, [expectedGroup3], EXCLUDE_CREATED_UPDATED_AT,HTTP_OK200);
+
+      cy.log("Query using less than createdAt - should not be included in results");
+      cy.apiGroupsCheck("gqGroupAdmin3", {"createdAt":{$lte:timestamp}}, [], [],HTTP_OK200);
+    });
+  });
+
+  it("Lists all user's groups by default", () => {
+      expectedGroup.Devices=[expectedDevice, expectedDevice1b];
+      expectedGroup.GroupUsers=[expectedGroupAdminGroupUser, expectedGroupMemberGroupUser];
+      expectedGroup.Users=[expectedGroupAdminUser];
+
+      expectedGroup2.GroupUsers=[expectedGroup2AdminGroupUser];
+      expectedGroup2.Users=[expectedGroup2AdminUser];
+
+      cy.apiGroupsCheck("gqGroupAdmin", {}, [expectedGroup, expectedGroup2], EXCLUDE_CREATED_UPDATED_AT, HTTP_OK200);
+  });
+
+  it("Can query using multuiple conditions - and and or operators", () => {
+    expectedGroup.Devices=[expectedDevice, expectedDevice1b];
+    expectedGroup.GroupUsers=[expectedGroupAdminGroupUser, expectedGroupMemberGroupUser];
+    expectedGroup.Users=[expectedGroupAdminUser];
+
+    cy.log("Query using two conditions - defaults to AND");
+    cy.apiGroupsCheck("gqGroupAdmin", {"groupname":getTestName("gqGroup"), "id":getCreds("gqGroup").id}, [expectedGroup], EXCLUDE_CREATED_UPDATED_AT);
+  });
+
+  it("Non member cannot query", () => {
+    cy.log("Valid user with no access to this group");
+    cy.apiGroupsCheck("gqTestUser", {"groupname":getTestName("gqGroup")}, [], [], HTTP_OK200);   
+
+    cy.log("Device admin with no group-level permisssions");
+    cy.apiGroupsCheck("gqDeviceAdmin", {"groupname":getTestName("gqGroup")}, [], [], HTTP_OK200);
+  });
+
+  it("Query nonexistant group handled correctly", () => {
+    cy.apiGroupsCheck("gqGroupAdmin", {"groupname":"IDontExist"}, [], [], HTTP_OK200);
+
+    cy.apiGroupsCheck("gqGroupAdmin", {"id":9999999}, [], [], HTTP_OK200);
+  });
+
+  it("Handles bad parameters correctly", () => {
+    cy.log("Invalid parameter");
+    cy.apiGroupsCheck("gqGroupAdmin", "ImNotAHash", [], [], HTTP_Unprocessable);
+
+    // TODO: FAILS with server error - Issue 78
+    //cy.log("Search on non-existant field");
+    //cy.apiGroupsCheck("gqGroupAdmin", {"KeyThatDoesNotExist": 1}, [], [], HTTP_Unprocessable);
+  });
+});
+

--- a/integration-tests/cypress/integration/api/groups/groups_query.ts
+++ b/integration-tests/cypress/integration/api/groups/groups_query.ts
@@ -1,66 +1,128 @@
 /// <reference path="../../../support/index.d.ts" />
 
-import { ApiGroupReturned, ApiGroupUserRelation, ApiDeviceIdAndName, ApiGroupUser } from "../../../commands/types";
+import {
+  ApiGroupReturned,
+  ApiGroupUserRelation,
+  ApiDeviceIdAndName,
+  ApiGroupUser,
+} from "../../../commands/types";
 import { getTestName } from "../../../commands/names";
 import { getCreds } from "../../../commands/server";
 
 import { HTTP_OK200 } from "../../../commands/constants";
 import { HTTP_Unprocessable } from "../../../commands/constants";
 
-const ADMIN=true;
-const NOT_ADMIN=false;
-let expectedGroup:ApiGroupReturned;
-let expectedGroup2:ApiGroupReturned;
-let expectedGroupAdminUser:ApiGroupUserRelation;
-let expectedGroupAdminGroupUser:ApiGroupUser;
-let expectedGroup2AdminUser:ApiGroupUserRelation;
-let expectedGroup2AdminGroupUser:ApiGroupUser;
-let expectedGroupMemberUser:ApiGroupUserRelation;
-let expectedGroupMemberGroupUser:ApiGroupUser;
-let expectedDevice:ApiDeviceIdAndName;
-let expectedDevice1b:ApiDeviceIdAndName;
-const EXCLUDE_CREATED_UPDATED_AT=["[].Users[].GroupUsers.createdAt","[].Users[].GroupUsers.updatedAt"];
+const ADMIN = true;
+const NOT_ADMIN = false;
+let expectedGroup: ApiGroupReturned;
+let expectedGroup2: ApiGroupReturned;
+let expectedGroupAdminUser: ApiGroupUserRelation;
+let expectedGroupAdminGroupUser: ApiGroupUser;
+let expectedGroup2AdminUser: ApiGroupUserRelation;
+let expectedGroup2AdminGroupUser: ApiGroupUser;
+let expectedGroupMemberUser: ApiGroupUserRelation;
+let expectedGroupMemberGroupUser: ApiGroupUser;
+let expectedDevice: ApiDeviceIdAndName;
+let expectedDevice1b: ApiDeviceIdAndName;
+const EXCLUDE_CREATED_UPDATED_AT = [
+  "[].Users[].GroupUsers.createdAt",
+  "[].Users[].GroupUsers.updatedAt",
+];
 
 describe("Groups - query groups", () => {
-
   before(() => {
     //admin user, group and device
-    cy.testCreateUserGroupAndDevice("gqGroupAdmin", "gqGroup", "gqCamera").then(() => {
-        expectedGroup={id:getCreds("gqGroup").id,groupname: getTestName("gqGroup"), 
-		Users: [],
-		Devices: [],
-		GroupUsers: []
-	};
-	expectedDevice={id: getCreds("gqCamera").id, devicename: getTestName("gqCamera")}
-	expectedGroupAdminUser={id: getCreds("gqGroupAdmin").id, username: getTestName("gqGroupAdmin"), GroupUsers: 
-          {admin: true, createdAt:"", updatedAt:"", GroupId: getCreds("gqGroup").id, UserId: getCreds("gqGroupAdmin").id}};
-        expectedGroupAdminGroupUser={id: getCreds("gqGroupAdmin").id, username: getTestName("gqGroupAdmin"), isAdmin:true};
-
-    });
+    cy.testCreateUserGroupAndDevice("gqGroupAdmin", "gqGroup", "gqCamera").then(
+      () => {
+        expectedGroup = {
+          id: getCreds("gqGroup").id,
+          groupname: getTestName("gqGroup"),
+          Users: [],
+          Devices: [],
+          GroupUsers: [],
+        };
+        expectedDevice = {
+          id: getCreds("gqCamera").id,
+          devicename: getTestName("gqCamera"),
+        };
+        expectedGroupAdminUser = {
+          id: getCreds("gqGroupAdmin").id,
+          username: getTestName("gqGroupAdmin"),
+          GroupUsers: {
+            admin: true,
+            createdAt: "",
+            updatedAt: "",
+            GroupId: getCreds("gqGroup").id,
+            UserId: getCreds("gqGroupAdmin").id,
+          },
+        };
+        expectedGroupAdminGroupUser = {
+          id: getCreds("gqGroupAdmin").id,
+          username: getTestName("gqGroupAdmin"),
+          isAdmin: true,
+        };
+      }
+    );
 
     //2nd group
     cy.apiGroupAdd("gqGroupAdmin", "gqGroup2").then(() => {
-        expectedGroup2={id:getCreds("gqGroup2").id,groupname: getTestName("gqGroup2"), 
-		Users: [],
-		Devices: [],
-		GroupUsers: []
-	};
-	expectedGroup2AdminUser={id: getCreds("gqGroupAdmin").id, username: getTestName("gqGroupAdmin"), GroupUsers: 
-          {admin: true, createdAt:"", updatedAt:"", GroupId: getCreds("gqGroup2").id, UserId: getCreds("gqGroupAdmin").id}};
-        expectedGroup2AdminGroupUser={id: getCreds("gqGroupAdmin").id, username: getTestName("gqGroupAdmin"), isAdmin:true};
+      expectedGroup2 = {
+        id: getCreds("gqGroup2").id,
+        groupname: getTestName("gqGroup2"),
+        Users: [],
+        Devices: [],
+        GroupUsers: [],
+      };
+      expectedGroup2AdminUser = {
+        id: getCreds("gqGroupAdmin").id,
+        username: getTestName("gqGroupAdmin"),
+        GroupUsers: {
+          admin: true,
+          createdAt: "",
+          updatedAt: "",
+          GroupId: getCreds("gqGroup2").id,
+          UserId: getCreds("gqGroupAdmin").id,
+        },
+      };
+      expectedGroup2AdminGroupUser = {
+        id: getCreds("gqGroupAdmin").id,
+        username: getTestName("gqGroupAdmin"),
+        isAdmin: true,
+      };
     });
 
     //2nd device in this group
-    cy.apiDeviceAdd("gqCamera1b","gqGroup").then(() => {
-      expectedDevice1b={id: getCreds("gqCamera1b").id, devicename: getTestName("gqCamera1b")};
+    cy.apiDeviceAdd("gqCamera1b", "gqGroup").then(() => {
+      expectedDevice1b = {
+        id: getCreds("gqCamera1b").id,
+        devicename: getTestName("gqCamera1b"),
+      };
     });
 
     //group member for this group
     cy.apiUserAdd("gqGroupMember");
-    cy.apiGroupUserAdd("gqGroupAdmin", "gqGroupMember", "gqGroup", NOT_ADMIN).then(() => {
-      expectedGroupMemberUser={id: getCreds("gqGroupMember").id, username: getTestName("gqGroupMember"), GroupUsers:
-            {admin: false, createdAt:"", updatedAt:"", GroupId: getCreds("gqGroup").id, UserId: getCreds("gqGroupMember").id}};
-      expectedGroupMemberGroupUser={id: getCreds("gqGroupMember").id, username: getTestName("gqGroupMember"), isAdmin:false};
+    cy.apiGroupUserAdd(
+      "gqGroupAdmin",
+      "gqGroupMember",
+      "gqGroup",
+      NOT_ADMIN
+    ).then(() => {
+      expectedGroupMemberUser = {
+        id: getCreds("gqGroupMember").id,
+        username: getTestName("gqGroupMember"),
+        GroupUsers: {
+          admin: false,
+          createdAt: "",
+          updatedAt: "",
+          GroupId: getCreds("gqGroup").id,
+          UserId: getCreds("gqGroupMember").id,
+        },
+      };
+      expectedGroupMemberGroupUser = {
+        id: getCreds("gqGroupMember").id,
+        username: getTestName("gqGroupMember"),
+        isAdmin: false,
+      };
     });
 
     //device admin for 1st device
@@ -72,80 +134,180 @@ describe("Groups - query groups", () => {
   });
 
   it("Admin and member can view group's devices and users", () => {
-     expectedGroup.Devices=[expectedDevice, expectedDevice1b];
-     expectedGroup.GroupUsers=[expectedGroupAdminGroupUser, expectedGroupMemberGroupUser];
-     let expectedGroup2=JSON.parse(JSON.stringify(expectedGroup));
+    expectedGroup.Devices = [expectedDevice, expectedDevice1b];
+    expectedGroup.GroupUsers = [
+      expectedGroupAdminGroupUser,
+      expectedGroupMemberGroupUser,
+    ];
+    const expectedGroup2 = JSON.parse(JSON.stringify(expectedGroup));
 
-     cy.log("Check admin can view group, devices and user");
-     expectedGroup.Users=[expectedGroupAdminUser];
-     cy.apiGroupsCheck("gqGroupAdmin", {"groupname":getTestName("gqGroup")}, [expectedGroup], EXCLUDE_CREATED_UPDATED_AT);
+    cy.log("Check admin can view group, devices and user");
+    expectedGroup.Users = [expectedGroupAdminUser];
+    cy.apiGroupsCheck(
+      "gqGroupAdmin",
+      { groupname: getTestName("gqGroup") },
+      [expectedGroup],
+      EXCLUDE_CREATED_UPDATED_AT
+    );
 
-     cy.log("Check member can view group, devices and user");
-     expectedGroup2.Users=[expectedGroupMemberUser];
-     cy.apiGroupsCheck("gqGroupMember", {"groupname":getTestName("gqGroup")}, [expectedGroup2], EXCLUDE_CREATED_UPDATED_AT);
+    cy.log("Check member can view group, devices and user");
+    expectedGroup2.Users = [expectedGroupMemberUser];
+    cy.apiGroupsCheck(
+      "gqGroupMember",
+      { groupname: getTestName("gqGroup") },
+      [expectedGroup2],
+      EXCLUDE_CREATED_UPDATED_AT
+    );
   });
 
-
   it("Can query using group id", () => {
-    expectedGroup.Devices=[expectedDevice, expectedDevice1b];
-    expectedGroup.GroupUsers=[expectedGroupAdminGroupUser, expectedGroupMemberGroupUser];
-    expectedGroup.Users=[expectedGroupAdminUser];
+    expectedGroup.Devices = [expectedDevice, expectedDevice1b];
+    expectedGroup.GroupUsers = [
+      expectedGroupAdminGroupUser,
+      expectedGroupMemberGroupUser,
+    ];
+    expectedGroup.Users = [expectedGroupAdminUser];
     //Query using group id
-    cy.apiGroupsCheck("gqGroupAdmin", {"id":getCreds("gqGroup").id}, [expectedGroup], EXCLUDE_CREATED_UPDATED_AT,HTTP_OK200);
+    cy.apiGroupsCheck(
+      "gqGroupAdmin",
+      { id: getCreds("gqGroup").id },
+      [expectedGroup],
+      EXCLUDE_CREATED_UPDATED_AT,
+      HTTP_OK200
+    );
   });
 
   it("Can query using other operators (>=, <) and createdAt", () => {
     // create a new group with a later timestamp
     const timestamp = new Date().toISOString();
-    let expectedGroup3:ApiGroupReturned;
-    cy.testCreateUserGroupAndDevice("gqGroupAdmin3", "gqGroup3", "gqCamera3").then(() => {
-      expectedGroup3={id:getCreds("gqGroup3").id,groupname: getTestName("gqGroup3"),
-        Users: [{id: getCreds("gqGroupAdmin3").id, username: getTestName("gqGroupAdmin3"), GroupUsers:
-          {admin: true, createdAt:"", updatedAt:"", GroupId: getCreds("gqGroup3").id, UserId: getCreds("gqGroupAdmin3").id}}],
-        Devices: [{id: getCreds("gqCamera3").id, devicename: getTestName("gqCamera3")}],
-        GroupUsers: [{id: getCreds("gqGroupAdmin3").id, username: getTestName("gqGroupAdmin3"), isAdmin:true}]
+    let expectedGroup3: ApiGroupReturned;
+    cy.testCreateUserGroupAndDevice(
+      "gqGroupAdmin3",
+      "gqGroup3",
+      "gqCamera3"
+    ).then(() => {
+      expectedGroup3 = {
+        id: getCreds("gqGroup3").id,
+        groupname: getTestName("gqGroup3"),
+        Users: [
+          {
+            id: getCreds("gqGroupAdmin3").id,
+            username: getTestName("gqGroupAdmin3"),
+            GroupUsers: {
+              admin: true,
+              createdAt: "",
+              updatedAt: "",
+              GroupId: getCreds("gqGroup3").id,
+              UserId: getCreds("gqGroupAdmin3").id,
+            },
+          },
+        ],
+        Devices: [
+          {
+            id: getCreds("gqCamera3").id,
+            devicename: getTestName("gqCamera3"),
+          },
+        ],
+        GroupUsers: [
+          {
+            id: getCreds("gqGroupAdmin3").id,
+            username: getTestName("gqGroupAdmin3"),
+            isAdmin: true,
+          },
+        ],
       };
 
-      cy.log("Query using greater than or equal to createdAt - should be included in results");
-      cy.apiGroupsCheck("gqGroupAdmin3", {"createdAt":{$gte:timestamp}}, [expectedGroup3], EXCLUDE_CREATED_UPDATED_AT,HTTP_OK200);
+      cy.log(
+        "Query using greater than or equal to createdAt - should be included in results"
+      );
+      cy.apiGroupsCheck(
+        "gqGroupAdmin3",
+        { createdAt: { $gte: timestamp } },
+        [expectedGroup3],
+        EXCLUDE_CREATED_UPDATED_AT,
+        HTTP_OK200
+      );
 
-      cy.log("Query using less than createdAt - should not be included in results");
-      cy.apiGroupsCheck("gqGroupAdmin3", {"createdAt":{$lte:timestamp}}, [], [],HTTP_OK200);
+      cy.log(
+        "Query using less than createdAt - should not be included in results"
+      );
+      cy.apiGroupsCheck(
+        "gqGroupAdmin3",
+        { createdAt: { $lte: timestamp } },
+        [],
+        [],
+        HTTP_OK200
+      );
     });
   });
 
   it("Lists all user's groups by default", () => {
-      expectedGroup.Devices=[expectedDevice, expectedDevice1b];
-      expectedGroup.GroupUsers=[expectedGroupAdminGroupUser, expectedGroupMemberGroupUser];
-      expectedGroup.Users=[expectedGroupAdminUser];
+    expectedGroup.Devices = [expectedDevice, expectedDevice1b];
+    expectedGroup.GroupUsers = [
+      expectedGroupAdminGroupUser,
+      expectedGroupMemberGroupUser,
+    ];
+    expectedGroup.Users = [expectedGroupAdminUser];
 
-      expectedGroup2.GroupUsers=[expectedGroup2AdminGroupUser];
-      expectedGroup2.Users=[expectedGroup2AdminUser];
+    expectedGroup2.GroupUsers = [expectedGroup2AdminGroupUser];
+    expectedGroup2.Users = [expectedGroup2AdminUser];
 
-      cy.apiGroupsCheck("gqGroupAdmin", {}, [expectedGroup, expectedGroup2], EXCLUDE_CREATED_UPDATED_AT, HTTP_OK200);
+    cy.apiGroupsCheck(
+      "gqGroupAdmin",
+      {},
+      [expectedGroup, expectedGroup2],
+      EXCLUDE_CREATED_UPDATED_AT,
+      HTTP_OK200
+    );
   });
 
   it("Can query using multuiple conditions - and and or operators", () => {
-    expectedGroup.Devices=[expectedDevice, expectedDevice1b];
-    expectedGroup.GroupUsers=[expectedGroupAdminGroupUser, expectedGroupMemberGroupUser];
-    expectedGroup.Users=[expectedGroupAdminUser];
+    expectedGroup.Devices = [expectedDevice, expectedDevice1b];
+    expectedGroup.GroupUsers = [
+      expectedGroupAdminGroupUser,
+      expectedGroupMemberGroupUser,
+    ];
+    expectedGroup.Users = [expectedGroupAdminUser];
 
     cy.log("Query using two conditions - defaults to AND");
-    cy.apiGroupsCheck("gqGroupAdmin", {"groupname":getTestName("gqGroup"), "id":getCreds("gqGroup").id}, [expectedGroup], EXCLUDE_CREATED_UPDATED_AT);
+    cy.apiGroupsCheck(
+      "gqGroupAdmin",
+      { groupname: getTestName("gqGroup"), id: getCreds("gqGroup").id },
+      [expectedGroup],
+      EXCLUDE_CREATED_UPDATED_AT
+    );
   });
 
   it("Non member cannot query", () => {
     cy.log("Valid user with no access to this group");
-    cy.apiGroupsCheck("gqTestUser", {"groupname":getTestName("gqGroup")}, [], [], HTTP_OK200);   
+    cy.apiGroupsCheck(
+      "gqTestUser",
+      { groupname: getTestName("gqGroup") },
+      [],
+      [],
+      HTTP_OK200
+    );
 
     cy.log("Device admin with no group-level permisssions");
-    cy.apiGroupsCheck("gqDeviceAdmin", {"groupname":getTestName("gqGroup")}, [], [], HTTP_OK200);
+    cy.apiGroupsCheck(
+      "gqDeviceAdmin",
+      { groupname: getTestName("gqGroup") },
+      [],
+      [],
+      HTTP_OK200
+    );
   });
 
   it("Query nonexistant group handled correctly", () => {
-    cy.apiGroupsCheck("gqGroupAdmin", {"groupname":"IDontExist"}, [], [], HTTP_OK200);
+    cy.apiGroupsCheck(
+      "gqGroupAdmin",
+      { groupname: "IDontExist" },
+      [],
+      [],
+      HTTP_OK200
+    );
 
-    cy.apiGroupsCheck("gqGroupAdmin", {"id":9999999}, [], [], HTTP_OK200);
+    cy.apiGroupsCheck("gqGroupAdmin", { id: 9999999 }, [], [], HTTP_OK200);
   });
 
   it("Handles bad parameters correctly", () => {
@@ -157,4 +319,3 @@ describe("Groups - query groups", () => {
     //cy.apiGroupsCheck("gqGroupAdmin", {"KeyThatDoesNotExist": 1}, [], [], HTTP_Unprocessable);
   });
 });
-

--- a/integration-tests/cypress/integration/api/groups/groups_query.ts
+++ b/integration-tests/cypress/integration/api/groups/groups_query.ts
@@ -25,7 +25,7 @@ describe("Groups - query groups", () => {
 
   before(() => {
     //admin user, group and device
-    cy.apiCreateUserGroupAndDevice("gqGroupAdmin", "gqGroup", "gqCamera").then(() => {
+    cy.testCreateUserGroupAndDevice("gqGroupAdmin", "gqGroup", "gqCamera").then(() => {
         expectedGroup={id:getCreds("gqGroup").id,groupname: getTestName("gqGroup"), 
 		Users: [],
 		Devices: [],
@@ -51,12 +51,12 @@ describe("Groups - query groups", () => {
     });
 
     //2nd device in this group
-    cy.apiCreateDevice("gqCamera1b","gqGroup").then(() => {
+    cy.apiDeviceAdd("gqCamera1b","gqGroup").then(() => {
       expectedDevice1b={id: getCreds("gqCamera1b").id, devicename: getTestName("gqCamera1b")};
     });
 
     //group member for this group
-    cy.apiCreateUser("gqGroupMember");
+    cy.apiUserAdd("gqGroupMember");
     cy.apiGroupUserAdd("gqGroupAdmin", "gqGroupMember", "gqGroup", NOT_ADMIN).then(() => {
       expectedGroupMemberUser={id: getCreds("gqGroupMember").id, username: getTestName("gqGroupMember"), GroupUsers:
             {admin: false, createdAt:"", updatedAt:"", GroupId: getCreds("gqGroup").id, UserId: getCreds("gqGroupMember").id}};
@@ -64,11 +64,11 @@ describe("Groups - query groups", () => {
     });
 
     //device admin for 1st device
-    cy.apiCreateUser("gqDeviceAdmin");
-    cy.apiAddUserToDevice("gqGroupAdmin", "gqDeviceAdmin", "gqCamera", ADMIN);
+    cy.apiUserAdd("gqDeviceAdmin");
+    cy.apiDeviceUserAdd("gqGroupAdmin", "gqDeviceAdmin", "gqCamera", ADMIN);
 
     // test users
-    cy.apiCreateUser("gqTestUser");
+    cy.apiUserAdd("gqTestUser");
   });
 
   it("Admin and member can view group's devices and users", () => {
@@ -98,7 +98,7 @@ describe("Groups - query groups", () => {
     // create a new group with a later timestamp
     const timestamp = new Date().toISOString();
     let expectedGroup3:ApiGroupReturned;
-    cy.apiCreateUserGroupAndDevice("gqGroupAdmin3", "gqGroup3", "gqCamera3").then(() => {
+    cy.testCreateUserGroupAndDevice("gqGroupAdmin3", "gqGroup3", "gqCamera3").then(() => {
       expectedGroup3={id:getCreds("gqGroup3").id,groupname: getTestName("gqGroup3"),
         Users: [{id: getCreds("gqGroupAdmin3").id, username: getTestName("gqGroupAdmin3"), GroupUsers:
           {admin: true, createdAt:"", updatedAt:"", GroupId: getCreds("gqGroup3").id, UserId: getCreds("gqGroupAdmin3").id}}],

--- a/integration-tests/cypress/integration/api/groups/groups_stations.ts
+++ b/integration-tests/cypress/integration/api/groups/groups_stations.ts
@@ -106,7 +106,12 @@ describe("Groups - add/update/query/remove stations from group", () => {
         expectedStation1a["retiredAt"] = null;
         expectedStation1a["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
 
-        cy.apiGroupsStationsCheck( "gsGroupAdmin", "gsGroupA", [expectedStation1a], EXCLUDE_CREATED_UPDATED_ID);
+        cy.apiGroupsStationsCheck(
+          "gsGroupAdmin",
+          "gsGroupA",
+          [expectedStation1a],
+          EXCLUDE_CREATED_UPDATED_ID
+        );
       }
     );
 
@@ -117,7 +122,12 @@ describe("Groups - add/update/query/remove stations from group", () => {
         expectedStation1b["retiredAt"] = null;
         expectedStation1b["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
 
-        cy.apiGroupsStationsCheck( "gsGroupAdmin", "gsGroupA", [expectedStation1b], EXCLUDE_CREATED_UPDATED_ID);
+        cy.apiGroupsStationsCheck(
+          "gsGroupAdmin",
+          "gsGroupA",
+          [expectedStation1b],
+          EXCLUDE_CREATED_UPDATED_ID
+        );
       }
     );
 
@@ -126,7 +136,12 @@ describe("Groups - add/update/query/remove stations from group", () => {
       expectedStation1b["GroupId"] = getCreds("gsGroupA").id;
       expectedStation1b["retiredAt"] = NOT_NULL;
       expectedStation1b["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
-      cy.apiGroupsStationsCheck( "gsGroupAdmin", "gsGroupA", [], EXCLUDE_CREATED_UPDATED_ID);
+      cy.apiGroupsStationsCheck(
+        "gsGroupAdmin",
+        "gsGroupA",
+        [],
+        EXCLUDE_CREATED_UPDATED_ID
+      );
     });
   });
 
@@ -139,24 +154,62 @@ describe("Groups - add/update/query/remove stations from group", () => {
         expectedStation1a["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
 
         cy.log("Check member can view station");
-        cy.apiGroupsStationsCheck( "gsGroupMember", "gsGroup", [expectedStation1a], EXCLUDE_CREATED_UPDATED_ID);
+        cy.apiGroupsStationsCheck(
+          "gsGroupMember",
+          "gsGroup",
+          [expectedStation1a],
+          EXCLUDE_CREATED_UPDATED_ID
+        );
 
         cy.log("Check member cannot add a station");
-        cy.apiGroupStationsUpdate( "gsGroupMember", "gsGroup", [station2a], undefined, HTTP_Forbidden).then(() => {
+        cy.apiGroupStationsUpdate(
+          "gsGroupMember",
+          "gsGroup",
+          [station2a],
+          undefined,
+          HTTP_Forbidden
+        ).then(() => {
           //station not added
-          cy.apiGroupsStationsCheck( "gsGroupMember", "gsGroup", [expectedStation1a], EXCLUDE_CREATED_UPDATED_ID);
+          cy.apiGroupsStationsCheck(
+            "gsGroupMember",
+            "gsGroup",
+            [expectedStation1a],
+            EXCLUDE_CREATED_UPDATED_ID
+          );
         });
 
         cy.log("Check member cannot update a station");
-        cy.apiGroupStationsUpdate( "gsGroupMember", "gsGroup", [station1b], undefined, HTTP_Forbidden).then(() => {
+        cy.apiGroupStationsUpdate(
+          "gsGroupMember",
+          "gsGroup",
+          [station1b],
+          undefined,
+          HTTP_Forbidden
+        ).then(() => {
           //station not added
-          cy.apiGroupsStationsCheck( "gsGroupMember", "gsGroup", [expectedStation1a], EXCLUDE_CREATED_UPDATED_ID);
+          cy.apiGroupsStationsCheck(
+            "gsGroupMember",
+            "gsGroup",
+            [expectedStation1a],
+            EXCLUDE_CREATED_UPDATED_ID
+          );
         });
 
         cy.log("Check member cannot retire a station");
-        cy.apiGroupStationsUpdate( "gsGroupMember", "gsGroup", [], undefined, HTTP_Forbidden).then(() => {
+        cy.apiGroupStationsUpdate(
+          "gsGroupMember",
+          "gsGroup",
+          [],
+          undefined,
+          HTTP_Forbidden
+        ).then(() => {
           //station not retired
-          cy.apiGroupsStationsCheck( "gsGroupMember", "gsGroup", [expectedStation1a], EXCLUDE_CREATED_UPDATED_ID);
+          cy.apiGroupsStationsCheck(
+            "gsGroupMember",
+            "gsGroup",
+            [expectedStation1a],
+            EXCLUDE_CREATED_UPDATED_ID
+          );
         });
       }
     );
@@ -170,24 +223,63 @@ describe("Groups - add/update/query/remove stations from group", () => {
         expectedStation1a["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
 
         cy.log("Check non-member cannot view station");
-        cy.apiGroupsStationsCheck( "gsTestUser", "gsGroup", [], null, HTTP_Forbidden);
+        cy.apiGroupsStationsCheck(
+          "gsTestUser",
+          "gsGroup",
+          [],
+          null,
+          HTTP_Forbidden
+        );
 
         cy.log("Check non-member cannot add a station");
-        cy.apiGroupStationsUpdate( "gsTestUser", "gsGroup", [station2a], undefined, HTTP_Forbidden).then(() => {
+        cy.apiGroupStationsUpdate(
+          "gsTestUser",
+          "gsGroup",
+          [station2a],
+          undefined,
+          HTTP_Forbidden
+        ).then(() => {
           //station not added
-          cy.apiGroupsStationsCheck( "gsGroupAdmin", "gsGroup", [expectedStation1a], EXCLUDE_CREATED_UPDATED_ID);
+          cy.apiGroupsStationsCheck(
+            "gsGroupAdmin",
+            "gsGroup",
+            [expectedStation1a],
+            EXCLUDE_CREATED_UPDATED_ID
+          );
         });
 
         cy.log("Check non-member cannot update a station");
-        cy.apiGroupStationsUpdate( "gsTestUser", "gsGroup", [station1b], undefined, HTTP_Forbidden).then(() => {
+        cy.apiGroupStationsUpdate(
+          "gsTestUser",
+          "gsGroup",
+          [station1b],
+          undefined,
+          HTTP_Forbidden
+        ).then(() => {
           //station not added
-          cy.apiGroupsStationsCheck( "gsGroupAdmin", "gsGroup", [expectedStation1a], EXCLUDE_CREATED_UPDATED_ID);
+          cy.apiGroupsStationsCheck(
+            "gsGroupAdmin",
+            "gsGroup",
+            [expectedStation1a],
+            EXCLUDE_CREATED_UPDATED_ID
+          );
         });
 
         cy.log("Check non-member cannot retire a station");
-        cy.apiGroupStationsUpdate( "gsTestUser", "gsGroup", [], undefined, HTTP_Forbidden).then(() => {
+        cy.apiGroupStationsUpdate(
+          "gsTestUser",
+          "gsGroup",
+          [],
+          undefined,
+          HTTP_Forbidden
+        ).then(() => {
           //station not retired
-          cy.apiGroupsStationsCheck( "gsGroupAdmin", "gsGroup", [expectedStation1a], EXCLUDE_CREATED_UPDATED_ID);
+          cy.apiGroupsStationsCheck(
+            "gsGroupAdmin",
+            "gsGroup",
+            [expectedStation1a],
+            EXCLUDE_CREATED_UPDATED_ID
+          );
         });
       }
     );
@@ -197,7 +289,10 @@ describe("Groups - add/update/query/remove stations from group", () => {
     cy.apiGroupAdd("gsGroupAdmin", "gsGroupD");
 
     cy.log("Add two stations");
-    cy.apiGroupStationsUpdate("gsGroupAdmin", "gsGroupD", [ station1a, station2a, ]).then(() => {
+    cy.apiGroupStationsUpdate("gsGroupAdmin", "gsGroupD", [
+      station1a,
+      station2a,
+    ]).then(() => {
       expectedStation1a["GroupId"] = getCreds("gsGroupD").id;
       expectedStation1a["retiredAt"] = null;
       expectedStation1a["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
@@ -206,12 +301,20 @@ describe("Groups - add/update/query/remove stations from group", () => {
       expectedStation2a["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
 
       //stations added
-      cy.apiGroupsStationsCheck( "gsGroupAdmin", "gsGroupD", [expectedStation1a, expectedStation2a], EXCLUDE_CREATED_UPDATED_ID);
+      cy.apiGroupsStationsCheck(
+        "gsGroupAdmin",
+        "gsGroupD",
+        [expectedStation1a, expectedStation2a],
+        EXCLUDE_CREATED_UPDATED_ID
+      );
     });
 
     //TODO Fails =: Issue 43
     cy.log("update two stations");
-    cy.apiGroupStationsUpdate("gsGroupAdmin", "gsGroupD", [ station1b, station2b, ]).then(() => {
+    cy.apiGroupStationsUpdate("gsGroupAdmin", "gsGroupD", [
+      station1b,
+      station2b,
+    ]).then(() => {
       expectedStation1b["GroupId"] = getCreds("gsGroupD").id;
       expectedStation1b["retiredAt"] = null;
       expectedStation1b["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
@@ -220,7 +323,12 @@ describe("Groups - add/update/query/remove stations from group", () => {
       expectedStation2b["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
 
       //stations updated
-      cy.apiGroupsStationsCheck( "gsGroupAdmin", "gsGroupD", [expectedStation1b, expectedStation2b], EXCLUDE_CREATED_UPDATED_ID);
+      cy.apiGroupsStationsCheck(
+        "gsGroupAdmin",
+        "gsGroupD",
+        [expectedStation1b, expectedStation2b],
+        EXCLUDE_CREATED_UPDATED_ID
+      );
     });
 
     //TODO: FAILS: Issue 44
@@ -234,7 +342,12 @@ describe("Groups - add/update/query/remove stations from group", () => {
       expectedStation2b["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
 
       //stations retired
-      cy.apiGroupsStationsCheck( "gsGroupAdmin", "gsGroupD", [expectedStation1b, expectedStation2b], EXCLUDE_CREATED_UPDATED_ID);
+      cy.apiGroupsStationsCheck(
+        "gsGroupAdmin",
+        "gsGroupD",
+        [expectedStation1b, expectedStation2b],
+        EXCLUDE_CREATED_UPDATED_ID
+      );
     });
   });
 
@@ -246,7 +359,10 @@ describe("Groups - add/update/query/remove stations from group", () => {
     //cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroupE", [station1a]);
     cy.log("Add and update station at same time");
 
-    cy.apiGroupStationsUpdate("gsGroupAdmin", "gsGroupE", [ station1b, station2b, ]).then(() => {
+    cy.apiGroupStationsUpdate("gsGroupAdmin", "gsGroupE", [
+      station1b,
+      station2b,
+    ]).then(() => {
       expectedStation1b["GroupId"] = getCreds("gsGroupE").id;
       expectedStation1b["retiredAt"] = null;
       expectedStation1b["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
@@ -255,7 +371,12 @@ describe("Groups - add/update/query/remove stations from group", () => {
       expectedStation2b["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
 
       //stations updated and added
-      cy.apiGroupsStationsCheck( "gsGroupAdmin", "gsGroupE", [expectedStation1b, expectedStation2b], EXCLUDE_CREATED_UPDATED_ID);
+      cy.apiGroupsStationsCheck(
+        "gsGroupAdmin",
+        "gsGroupE",
+        [expectedStation1b, expectedStation2b],
+        EXCLUDE_CREATED_UPDATED_ID
+      );
     });
 
     cy.log("retire a station");
@@ -269,7 +390,12 @@ describe("Groups - add/update/query/remove stations from group", () => {
         expectedStation2b["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
 
         //stations deleted
-        cy.apiGroupsStationsCheck( "gsGroupAdmin", "gsGroupE", [expectedStation1b, expectedStation2b], EXCLUDE_CREATED_UPDATED_ID);
+        cy.apiGroupsStationsCheck(
+          "gsGroupAdmin",
+          "gsGroupE",
+          [expectedStation1b, expectedStation2b],
+          EXCLUDE_CREATED_UPDATED_ID
+        );
       }
     );
 
@@ -287,76 +413,173 @@ describe("Groups - add/update/query/remove stations from group", () => {
         expectedStation3a["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
 
         //stations deleted and added
-        cy.apiGroupsStationsCheck( "gsGroupAdmin", "gsGroupE", [expectedStation1b, expectedStation2b, expectedStation3a], EXCLUDE_CREATED_UPDATED_ID);
+        cy.apiGroupsStationsCheck(
+          "gsGroupAdmin",
+          "gsGroupE",
+          [expectedStation1b, expectedStation2b, expectedStation3a],
+          EXCLUDE_CREATED_UPDATED_ID
+        );
       }
     );
   });
 
   it("Invalid group handled correctly", () => {
-    cy.apiGroupStationsUpdate( "gsGroupAdmin", "ThisGroupDoesNotExist", [station3a], undefined, HTTP_Unprocessable);
-    cy.apiGroupsStationsCheck( "gsGroupAdmin", "ThisGroupDoesNotExist", [], undefined, HTTP_Unprocessable);
+    cy.apiGroupStationsUpdate(
+      "gsGroupAdmin",
+      "ThisGroupDoesNotExist",
+      [station3a],
+      undefined,
+      HTTP_Unprocessable
+    );
+    cy.apiGroupsStationsCheck(
+      "gsGroupAdmin",
+      "ThisGroupDoesNotExist",
+      [],
+      undefined,
+      HTTP_Unprocessable
+    );
   });
 
   it("Invalid stations parameters handled correctly", () => {
     let badStation: ApiStationData = { name: "hello", lat: null, lng: 172 };
-    cy.apiGroupStationsUpdate( "gsGroupAdmin", "gsGroup", [badStation], undefined, HTTP_Unprocessable);
+    cy.apiGroupStationsUpdate(
+      "gsGroupAdmin",
+      "gsGroup",
+      [badStation],
+      undefined,
+      HTTP_Unprocessable
+    );
 
     badStation = { name: "hello", lat: "string", lng: 172 };
-    cy.apiGroupStationsUpdate( "gsGroupAdmin", "gsGroup", [badStation], undefined, HTTP_Unprocessable);
+    cy.apiGroupStationsUpdate(
+      "gsGroupAdmin",
+      "gsGroup",
+      [badStation],
+      undefined,
+      HTTP_Unprocessable
+    );
 
     badStation = { name: "hello", lng: 172 };
-    cy.apiGroupStationsUpdate( "gsGroupAdmin", "gsGroup", [badStation], undefined, HTTP_Unprocessable);
+    cy.apiGroupStationsUpdate(
+      "gsGroupAdmin",
+      "gsGroup",
+      [badStation],
+      undefined,
+      HTTP_Unprocessable
+    );
 
     badStation = { name: "hello", lat: -45, lng: null };
-    cy.apiGroupStationsUpdate( "gsGroupAdmin", "gsGroup", [badStation], undefined, HTTP_Unprocessable);
+    cy.apiGroupStationsUpdate(
+      "gsGroupAdmin",
+      "gsGroup",
+      [badStation],
+      undefined,
+      HTTP_Unprocessable
+    );
 
     badStation = { name: "hello", lat: -45 };
-    cy.apiGroupStationsUpdate( "gsGroupAdmin", "gsGroup", [badStation], undefined, HTTP_Unprocessable);
+    cy.apiGroupStationsUpdate(
+      "gsGroupAdmin",
+      "gsGroup",
+      [badStation],
+      undefined,
+      HTTP_Unprocessable
+    );
 
     badStation = { name: "hello", lat: -45, lng: "string" };
-    cy.apiGroupStationsUpdate( "gsGroupAdmin", "gsGroup", [badStation], undefined, HTTP_Unprocessable);
+    cy.apiGroupStationsUpdate(
+      "gsGroupAdmin",
+      "gsGroup",
+      [badStation],
+      undefined,
+      HTTP_Unprocessable
+    );
 
     badStation = { name: null, lat: -45, lng: 172 };
-    cy.apiGroupStationsUpdate( "gsGroupAdmin", "gsGroup", [badStation], undefined, HTTP_Unprocessable);
+    cy.apiGroupStationsUpdate(
+      "gsGroupAdmin",
+      "gsGroup",
+      [badStation],
+      undefined,
+      HTTP_Unprocessable
+    );
 
     badStation = { lat: -45, lng: "string" };
-    cy.apiGroupStationsUpdate( "gsGroupAdmin", "gsGroup", [badStation], undefined, HTTP_Unprocessable);
+    cy.apiGroupStationsUpdate(
+      "gsGroupAdmin",
+      "gsGroup",
+      [badStation],
+      undefined,
+      HTTP_Unprocessable
+    );
 
     badStation = { name: "hello", lat: -45, lng: 172, randomParameter: true };
     //unexpected parameters ignored
     //cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroup",[badStation],undefined,HTTP_Unprocessable);
-    cy.apiGroupStationsUpdate( "gsGroupAdmin", "gsGroup", [badStation], undefined, HTTP_OK200);
+    cy.apiGroupStationsUpdate(
+      "gsGroupAdmin",
+      "gsGroup",
+      [badStation],
+      undefined,
+      HTTP_OK200
+    );
 
     //but a valid one still works
-    cy.apiGroupStationsUpdate( "gsGroupAdmin", "gsGroup", [station1a], undefined, HTTP_OK200);
+    cy.apiGroupStationsUpdate(
+      "gsGroupAdmin",
+      "gsGroup",
+      [station1a],
+      undefined,
+      HTTP_OK200
+    );
   });
 
   it("Stations too close rejected", () => {
-   cy.apiGroupAdd("gsGroupAdmin", "gsGroupG");
+    cy.apiGroupAdd("gsGroupAdmin", "gsGroupG");
     cy.log("Add a station");
-    cy.apiGroupStationsUpdate("gsGroupAdmin", "gsGroupG", [ station1a ]);
+    cy.apiGroupStationsUpdate("gsGroupAdmin", "gsGroupG", [station1a]);
 
     cy.log("Attempt to add another too close");
-    let badStation = { name: "tooClose", lat: -45.100001, lng: 172.100001 };
-    cy.apiGroupStationsUpdate("gsGroupAdmin", "gsGroupG", [ station1a, badStation ],undefined,HTTP_OK200,{warnings: ["Stations too close together"]});
+    const badStation = { name: "tooClose", lat: -45.100001, lng: 172.100001 };
+    cy.apiGroupStationsUpdate(
+      "gsGroupAdmin",
+      "gsGroupG",
+      [station1a, badStation],
+      undefined,
+      HTTP_OK200,
+      { warnings: ["Stations too close together"] }
+    );
 
     cy.log("Attempt to add two too close at same time");
-    let badStation1 = { name: "tooClose", lat: -45.500001, lng: 172.100001 };
-    let badStation2 = { name: "tooClose", lat: -45.500002, lng: 172.100001 };
-    cy.apiGroupStationsUpdate("gsGroupAdmin", "gsGroupG", [ station1a, badStation1, badStation2], undefined, HTTP_OK200, {warnings: ["Stations too close together"] });
+    const badStation1 = { name: "tooClose", lat: -45.500001, lng: 172.100001 };
+    const badStation2 = { name: "tooClose", lat: -45.500002, lng: 172.100001 };
+    cy.apiGroupStationsUpdate(
+      "gsGroupAdmin",
+      "gsGroupG",
+      [station1a, badStation1, badStation2],
+      undefined,
+      HTTP_OK200,
+      { warnings: ["Stations too close together"] }
+    );
   });
 
   it("Add new station with same name as retired station - both kept", () => {
-   cy.apiGroupAdd("gsGroupAdmin", "gsGroupF");
-  
+    cy.apiGroupAdd("gsGroupAdmin", "gsGroupF");
+
     cy.log("Add two stations");
-    cy.apiGroupStationsUpdate("gsGroupAdmin", "gsGroupF", [ station1a, station2a ]);
-  
+    cy.apiGroupStationsUpdate("gsGroupAdmin", "gsGroupF", [
+      station1a,
+      station2a,
+    ]);
+
     cy.log("retire station");
-    cy.apiGroupStationsUpdate("gsGroupAdmin", "gsGroupF", [ station1a ]);
+    cy.apiGroupStationsUpdate("gsGroupAdmin", "gsGroupF", [station1a]);
 
     cy.log("Re-add new station");
-    cy.apiGroupStationsUpdate("gsGroupAdmin", "gsGroupF", [ station1a, station2b ]).then(() => {
+    cy.apiGroupStationsUpdate("gsGroupAdmin", "gsGroupF", [
+      station1a,
+      station2b,
+    ]).then(() => {
       expectedStation1a["GroupId"] = getCreds("gsGroupF").id;
       expectedStation1a["retiredAt"] = null;
       expectedStation1a["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
@@ -367,25 +590,53 @@ describe("Groups - add/update/query/remove stations from group", () => {
       expectedStation2b["retiredAt"] = null;
       expectedStation2b["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
 
-      //check both retired and new station shows 
-      cy.apiGroupsStationsCheck( "gsGroupAdmin", "gsGroupF", [expectedStation1a, expectedStation2a, expectedStation2b], EXCLUDE_CREATED_UPDATED_ID);
-      
+      //check both retired and new station shows
+      cy.apiGroupsStationsCheck(
+        "gsGroupAdmin",
+        "gsGroupF",
+        [expectedStation1a, expectedStation2a, expectedStation2b],
+        EXCLUDE_CREATED_UPDATED_ID
+      );
     });
   });
 
   it("From date validated correctly", () => {
     const timestamp = new Date().toISOString();
     cy.log("from date timestamp accepted");
-    cy.apiGroupStationsUpdate( "gsGroupAdmin", "gsGroup", [station1a], timestamp, HTTP_OK200);
+    cy.apiGroupStationsUpdate(
+      "gsGroupAdmin",
+      "gsGroup",
+      [station1a],
+      timestamp,
+      HTTP_OK200
+    );
 
     cy.log("from date absent accepted");
-    cy.apiGroupStationsUpdate( "gsGroupAdmin", "gsGroup", [station1a], undefined, HTTP_OK200);
+    cy.apiGroupStationsUpdate(
+      "gsGroupAdmin",
+      "gsGroup",
+      [station1a],
+      undefined,
+      HTTP_OK200
+    );
 
     cy.log("from date blank rejected");
-    cy.apiGroupStationsUpdate( "gsGroupAdmin", "gsGroup", [station1a], "", HTTP_Unprocessable);
+    cy.apiGroupStationsUpdate(
+      "gsGroupAdmin",
+      "gsGroup",
+      [station1a],
+      "",
+      HTTP_Unprocessable
+    );
 
     cy.log("malformed from date rejected");
-    cy.apiGroupStationsUpdate( "gsGroupAdmin", "gsGroup", [station1a], "ThisIsNotADate", HTTP_Unprocessable);
+    cy.apiGroupStationsUpdate(
+      "gsGroupAdmin",
+      "gsGroup",
+      [station1a],
+      "ThisIsNotADate",
+      HTTP_Unprocessable
+    );
   });
 
   //Mapping of recording to stations tested in the recordings section

--- a/integration-tests/cypress/integration/api/groups/groups_stations.ts
+++ b/integration-tests/cypress/integration/api/groups/groups_stations.ts
@@ -30,7 +30,7 @@ describe("Groups - add/update/query/remove stations from group", () => {
 
   before(() => {
     //admin user, group and device
-    cy.apiCreateUserGroupAndDevice("gsGroupAdmin", "gsGroup", "gsCamera").then(() => {
+    cy.testCreateUserGroupAndDevice("gsGroupAdmin", "gsGroup", "gsCamera").then(() => {
     });
 
     //2nd group
@@ -38,24 +38,24 @@ describe("Groups - add/update/query/remove stations from group", () => {
     });
 
     //2nd device in first group
-    cy.apiCreateDevice("gsCamera1b","gsGroup").then(() => {
+    cy.apiDeviceAdd("gsCamera1b","gsGroup").then(() => {
     });
 
     //group member for this group
-    cy.apiCreateUser("gsGroupMember");
+    cy.apiUserAdd("gsGroupMember");
     cy.apiGroupUserAdd("gsGroupAdmin", "gsGroupMember", "gsGroup", NOT_ADMIN);
 
     //device admin for 1st device
-    cy.apiCreateUser("gsDeviceAdmin");
-    cy.apiAddUserToDevice("gsGroupAdmin", "gsDeviceAdmin", "gsCamera", ADMIN);
+    cy.apiUserAdd("gsDeviceAdmin");
+    cy.apiDeviceUserAdd("gsGroupAdmin", "gsDeviceAdmin", "gsCamera", ADMIN);
 
     // test users
-    cy.apiCreateUser("gsTestUser");
+    cy.apiUserAdd("gsTestUser");
   });
 
   it.skip("Group admin can add, update, retire and query stations from a group", () => {
     cy.apiGroupAdd("gsGroupAdmin", "gsGroupA");
-    cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroupA", [station1a]).then(() => {
+    cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroupA", [station1a]).then(() => {
       expectedStation1a["GroupId"]=getCreds("gsGroupA").id;
       expectedStation1a["retiredAt"]=null;
       expectedStation1a["lastUpdatedById"]=getCreds("gsGroupAdmin").id; 
@@ -64,7 +64,7 @@ describe("Groups - add/update/query/remove stations from group", () => {
     });
 
     //TODO: FAIL - issue 43
-    cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroupA", [station1b]).then(() => {
+    cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroupA", [station1b]).then(() => {
       expectedStation1b["GroupId"]=getCreds("gsGroupA").id;
       expectedStation1b["retiredAt"]=null;
       expectedStation1b["lastUpdatedById"]=getCreds("gsGroupAdmin").id;
@@ -73,7 +73,7 @@ describe("Groups - add/update/query/remove stations from group", () => {
     });
 
     //TODO: FAIL - Issue 44
-    cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroupA", []).then(() => {
+    cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroupA", []).then(() => {
       expectedStation1b["GroupId"]=getCreds("gsGroupA").id;
       expectedStation1b["retiredAt"]=NOT_NULL;
       expectedStation1b["lastUpdatedById"]=getCreds("gsGroupAdmin").id;
@@ -85,7 +85,7 @@ describe("Groups - add/update/query/remove stations from group", () => {
 
   it("Group member can query but not add, update, retire stations from a group", () => {
     cy.log("Add a station as admin to test with");
-    cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroup", [station1a]).then(() => {
+    cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroup", [station1a]).then(() => {
       expectedStation1a["GroupId"]=getCreds("gsGroup").id;
       expectedStation1a["retiredAt"]=null;
       expectedStation1a["lastUpdatedById"]=getCreds("gsGroupAdmin").id;
@@ -94,19 +94,19 @@ describe("Groups - add/update/query/remove stations from group", () => {
       cy.apiGroupsStationsCheck("gsGroupMember","gsGroup",[expectedStation1a],EXCLUDE_CREATED_UPDATED_ID);
 
       cy.log("Check member cannot add a station");
-      cy.apiGroupsStationsUpdate("gsGroupMember","gsGroup", [station2a],undefined,HTTP_Forbidden).then(() => {
+      cy.apiGroupStationsUpdate("gsGroupMember","gsGroup", [station2a],undefined,HTTP_Forbidden).then(() => {
         //station not added
         cy.apiGroupsStationsCheck("gsGroupMember","gsGroup",[expectedStation1a],EXCLUDE_CREATED_UPDATED_ID);
       });
 
       cy.log("Check member cannot update a station");
-      cy.apiGroupsStationsUpdate("gsGroupMember","gsGroup", [station1b],undefined,HTTP_Forbidden).then(() => {
+      cy.apiGroupStationsUpdate("gsGroupMember","gsGroup", [station1b],undefined,HTTP_Forbidden).then(() => {
         //station not added
         cy.apiGroupsStationsCheck("gsGroupMember","gsGroup",[expectedStation1a],EXCLUDE_CREATED_UPDATED_ID);
       });
 
       cy.log("Check member cannot retire a station");
-      cy.apiGroupsStationsUpdate("gsGroupMember","gsGroup", [],undefined,HTTP_Forbidden).then(() => {
+      cy.apiGroupStationsUpdate("gsGroupMember","gsGroup", [],undefined,HTTP_Forbidden).then(() => {
         //station not retired
         cy.apiGroupsStationsCheck("gsGroupMember","gsGroup",[expectedStation1a],EXCLUDE_CREATED_UPDATED_ID);
       });
@@ -114,7 +114,7 @@ describe("Groups - add/update/query/remove stations from group", () => {
   });
 
   it("Non group members cannot add, update, retire or query stations", () => {
-     cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroup", [station1a]).then(() => {
+     cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroup", [station1a]).then(() => {
       expectedStation1a["GroupId"]=getCreds("gsGroup").id;
       expectedStation1a["retiredAt"]=null;
       expectedStation1a["lastUpdatedById"]=getCreds("gsGroupAdmin").id;
@@ -123,19 +123,19 @@ describe("Groups - add/update/query/remove stations from group", () => {
       cy.apiGroupsStationsCheck("gsTestUser","gsGroup",[],null,HTTP_Forbidden);
 
       cy.log("Check non-member cannot add a station");
-      cy.apiGroupsStationsUpdate("gsTestUser","gsGroup", [station2a],undefined,HTTP_Forbidden).then(() => {
+      cy.apiGroupStationsUpdate("gsTestUser","gsGroup", [station2a],undefined,HTTP_Forbidden).then(() => {
         //station not added
         cy.apiGroupsStationsCheck("gsGroupAdmin","gsGroup",[expectedStation1a],EXCLUDE_CREATED_UPDATED_ID);
       });
 
       cy.log("Check non-member cannot update a station");
-      cy.apiGroupsStationsUpdate("gsTestUser","gsGroup", [station1b],undefined,HTTP_Forbidden).then(() => {
+      cy.apiGroupStationsUpdate("gsTestUser","gsGroup", [station1b],undefined,HTTP_Forbidden).then(() => {
         //station not added
         cy.apiGroupsStationsCheck("gsGroupAdmin","gsGroup",[expectedStation1a],EXCLUDE_CREATED_UPDATED_ID);
       });
 
       cy.log("Check non-member cannot retire a station");
-      cy.apiGroupsStationsUpdate("gsTestUser","gsGroup", [],undefined,HTTP_Forbidden).then(() => {
+      cy.apiGroupStationsUpdate("gsTestUser","gsGroup", [],undefined,HTTP_Forbidden).then(() => {
         //station not retired
         cy.apiGroupsStationsCheck("gsGroupAdmin","gsGroup",[expectedStation1a],EXCLUDE_CREATED_UPDATED_ID);
       });
@@ -147,7 +147,7 @@ describe("Groups - add/update/query/remove stations from group", () => {
     cy.apiGroupAdd("gsGroupAdmin", "gsGroupD");
 
     cy.log("Add two stations");
-    cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroupD", [station1a, station2a]).then(() => {
+    cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroupD", [station1a, station2a]).then(() => {
       expectedStation1a["GroupId"]=getCreds("gsGroupD").id;
       expectedStation1a["retiredAt"]=null;
       expectedStation1a["lastUpdatedById"]=getCreds("gsGroupAdmin").id;
@@ -162,7 +162,7 @@ describe("Groups - add/update/query/remove stations from group", () => {
 
     //TODO Fails =: Issue 43
     cy.log("update two stations");
-    cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroupD", [station1b, station2b]).then(() => {
+    cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroupD", [station1b, station2b]).then(() => {
       expectedStation1b["GroupId"]=getCreds("gsGroupD").id;
       expectedStation1b["retiredAt"]=null;
       expectedStation1b["lastUpdatedById"]=getCreds("gsGroupAdmin").id;
@@ -177,7 +177,7 @@ describe("Groups - add/update/query/remove stations from group", () => {
 
     //TODO: FAILS: Issue 44
     cy.log("retire two stations");
-    cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroupD", []).then(() => {
+    cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroupD", []).then(() => {
       expectedStation1b["GroupId"]=getCreds("gsGroupD").id;
       expectedStation1b["retiredAt"]=NOT_NULL;
       expectedStation1b["lastUpdatedById"]=getCreds("gsGroupAdmin").id;
@@ -196,10 +196,10 @@ describe("Groups - add/update/query/remove stations from group", () => {
 
     //add a station to test with
     ////TODO: Issue 44. enabled when fixed - not adding as later update will fail
-    //cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroupE", [station1a]);
+    //cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroupE", [station1a]);
     cy.log("Add and update station at same time");
 
-    cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroupE", [station1b, station2b]).then(() => {
+    cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroupE", [station1b, station2b]).then(() => {
       expectedStation1b["GroupId"]=getCreds("gsGroupE").id;
       expectedStation1b["retiredAt"]=null;
       expectedStation1b["lastUpdatedById"]=getCreds("gsGroupAdmin").id;
@@ -213,7 +213,7 @@ describe("Groups - add/update/query/remove stations from group", () => {
 
 
     cy.log("retire a station");
-    cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroupE", [station1b]).then(() => {
+    cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroupE", [station1b]).then(() => {
       expectedStation1b["GroupId"]=getCreds("gsGroupE").id;
       expectedStation1b["retiredAt"]=null;
       expectedStation1b["lastUpdatedById"]=getCreds("gsGroupAdmin").id;
@@ -226,7 +226,7 @@ describe("Groups - add/update/query/remove stations from group", () => {
     });
 
     cy.log("retire and add a station");
-    cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroupE", [station3a]).then(() => {
+    cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroupE", [station3a]).then(() => {
       expectedStation1b["GroupId"]=getCreds("gsGroupE").id;
       expectedStation1b["retiredAt"]=NOT_NULL;
       expectedStation1b["lastUpdatedById"]=getCreds("gsGroupAdmin").id;
@@ -245,57 +245,57 @@ describe("Groups - add/update/query/remove stations from group", () => {
   });
 
   it("Invalid group handled correctly", () => {
-    cy.apiGroupsStationsUpdate("gsGroupAdmin","ThisGroupDoesNotExist", [station3a], undefined, HTTP_Unprocessable);
+    cy.apiGroupStationsUpdate("gsGroupAdmin","ThisGroupDoesNotExist", [station3a], undefined, HTTP_Unprocessable);
     cy.apiGroupsStationsCheck("gsGroupAdmin","ThisGroupDoesNotExist", [], undefined, HTTP_Unprocessable);
   });
 
   it("Invalid stations parameters handled correctly", () => {
     let badStation:ApiStationData={name: "hello", lat: null, lng: 172};
-    cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroup",[badStation],undefined,HTTP_Unprocessable);
+    cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroup",[badStation],undefined,HTTP_Unprocessable);
 
     badStation={name: "hello", lat: "string", lng: 172};
-    cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroup",[badStation],undefined,HTTP_Unprocessable);
+    cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroup",[badStation],undefined,HTTP_Unprocessable);
 
     badStation={name: "hello", lng: 172};
-    cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroup",[badStation],undefined,HTTP_Unprocessable);
+    cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroup",[badStation],undefined,HTTP_Unprocessable);
 
     badStation={name: "hello", lat: -45, lng: null};
-    cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroup",[badStation],undefined,HTTP_Unprocessable);
+    cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroup",[badStation],undefined,HTTP_Unprocessable);
 
     badStation={name: "hello", lat: -45};
-    cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroup",[badStation],undefined,HTTP_Unprocessable);
+    cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroup",[badStation],undefined,HTTP_Unprocessable);
 
     badStation={name: "hello", lat: -45, lng: "string"};
-    cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroup",[badStation],undefined,HTTP_Unprocessable);
+    cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroup",[badStation],undefined,HTTP_Unprocessable);
 
     badStation={name: null, lat: -45, lng: 172};
-    cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroup",[badStation],undefined,HTTP_Unprocessable);
+    cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroup",[badStation],undefined,HTTP_Unprocessable);
 
     badStation={lat: -45, lng: "string"};
-    cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroup",[badStation],undefined,HTTP_Unprocessable);
+    cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroup",[badStation],undefined,HTTP_Unprocessable);
 
     badStation={name: "hello", lat: -45, lng: 172, randomParameter: true};
     //unexpected parameters ignored 
-    //cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroup",[badStation],undefined,HTTP_Unprocessable);
-    cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroup",[badStation],undefined,HTTP_OK200);
+    //cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroup",[badStation],undefined,HTTP_Unprocessable);
+    cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroup",[badStation],undefined,HTTP_OK200);
 
     //but a valid one still works
-    cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroup",[station1a],undefined,HTTP_OK200);
+    cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroup",[station1a],undefined,HTTP_OK200);
   });
 
   it("From date validated correctly", () => {
     let timestamp = new Date().toISOString();
     cy.log("from date timestamp accepted");
-    cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroup",[station1a],timestamp,HTTP_OK200);
+    cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroup",[station1a],timestamp,HTTP_OK200);
 
     cy.log("from date absent accepted");
-    cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroup",[station1a],undefined,HTTP_OK200);
+    cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroup",[station1a],undefined,HTTP_OK200);
 
     cy.log("from date blank rejected");
-    cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroup",[station1a],"",HTTP_Unprocessable);
+    cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroup",[station1a],"",HTTP_Unprocessable);
 
     cy.log("malformed from date rejected");
-    cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroup",[station1a],"ThisIsNotADate",HTTP_Unprocessable);
+    cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroup",[station1a],"ThisIsNotADate",HTTP_Unprocessable);
   });
 
   //Mapping of recording to stations tested in the recordings section

--- a/integration-tests/cypress/integration/api/groups/groups_stations.ts
+++ b/integration-tests/cypress/integration/api/groups/groups_stations.ts
@@ -1,6 +1,9 @@
 /// <reference path="../../../support/index.d.ts" />
 
-import { ApiStationData, ApiStationDataReturned } from "../../../commands/types";
+import {
+  ApiStationData,
+  ApiStationDataReturned,
+} from "../../../commands/types";
 import { getCreds } from "../../../commands/server";
 
 import { HTTP_OK200 } from "../../../commands/constants";
@@ -8,38 +11,80 @@ import { HTTP_Forbidden } from "../../../commands/constants";
 import { HTTP_Unprocessable } from "../../../commands/constants";
 import { NOT_NULL } from "../../../commands/constants";
 
-const ADMIN=true;
-const NOT_ADMIN=false;
-const EXCLUDE_CREATED_UPDATED_ID=["[].createdAt","[].updatedAt","[].id"];
+const ADMIN = true;
+const NOT_ADMIN = false;
+const EXCLUDE_CREATED_UPDATED_ID = ["[].createdAt", "[].updatedAt", "[].id"];
 
-let station1a={name: "station1", lat: -45.1, lng: 172.1};
-let station1b={name: "station1", lat: -45.2, lng: 172.1};
-let station2a={name: "station2", lat: -45.1, lng: 172.2};
-let station2b={name: "station2", lat: -45.2, lng: 172.2};
-let station3a={name: "station3", lat: -45.1, lng: 172.3};
+const station1a = { name: "station1", lat: -45.1, lng: 172.1 };
+const station1b = { name: "station1", lat: -45.2, lng: 172.1 };
+const station2a = { name: "station2", lat: -45.1, lng: 172.2 };
+const station2b = { name: "station2", lat: -45.2, lng: 172.2 };
+const station3a = { name: "station3", lat: -45.1, lng: 172.3 };
 
 //TODO: These coordinates are back to front.  Issue 73. Reverse once database & API are corrected. Should be X,Y
-let expectedStation1a:ApiStationDataReturned={ id:0, name: "station1", location:{type: "Point", coordinates:  [-45.1,172.1]}, lastUpdatedById: 0, createdAt: null, retiredAt: null, updatedAt: null, GroupId: null};
-let expectedStation1b:ApiStationDataReturned={ id:0, name: "station1", location:{type: "Point", coordinates:  [-45.2,172.1]}, lastUpdatedById: 0, createdAt: null, retiredAt: null, updatedAt: null, GroupId: null};
-let expectedStation2a:ApiStationDataReturned={ id:0, name: "station2", location:{type: "Point", coordinates:  [-45.1,172.2]}, lastUpdatedById: 0, createdAt: null, retiredAt: null, updatedAt: null, GroupId: null};
-let expectedStation2b:ApiStationDataReturned={ id:0, name: "station2", location:{type: "Point", coordinates:  [-45.2,172.2]}, lastUpdatedById: 0, createdAt: null, retiredAt: null, updatedAt: null, GroupId: null};
-let expectedStation3a:ApiStationDataReturned={ id:0, name: "station3", location:{type: "Point", coordinates:  [-45.1,172.3]}, lastUpdatedById: 0, createdAt: null, retiredAt: null, updatedAt: null, GroupId: null};
-
+const expectedStation1a: ApiStationDataReturned = {
+  id: 0,
+  name: "station1",
+  location: { type: "Point", coordinates: [-45.1, 172.1] },
+  lastUpdatedById: 0,
+  createdAt: null,
+  retiredAt: null,
+  updatedAt: null,
+  GroupId: null,
+};
+const expectedStation1b: ApiStationDataReturned = {
+  id: 0,
+  name: "station1",
+  location: { type: "Point", coordinates: [-45.2, 172.1] },
+  lastUpdatedById: 0,
+  createdAt: null,
+  retiredAt: null,
+  updatedAt: null,
+  GroupId: null,
+};
+const expectedStation2a: ApiStationDataReturned = {
+  id: 0,
+  name: "station2",
+  location: { type: "Point", coordinates: [-45.1, 172.2] },
+  lastUpdatedById: 0,
+  createdAt: null,
+  retiredAt: null,
+  updatedAt: null,
+  GroupId: null,
+};
+const expectedStation2b: ApiStationDataReturned = {
+  id: 0,
+  name: "station2",
+  location: { type: "Point", coordinates: [-45.2, 172.2] },
+  lastUpdatedById: 0,
+  createdAt: null,
+  retiredAt: null,
+  updatedAt: null,
+  GroupId: null,
+};
+const expectedStation3a: ApiStationDataReturned = {
+  id: 0,
+  name: "station3",
+  location: { type: "Point", coordinates: [-45.1, 172.3] },
+  lastUpdatedById: 0,
+  createdAt: null,
+  retiredAt: null,
+  updatedAt: null,
+  GroupId: null,
+};
 
 describe("Groups - add/update/query/remove stations from group", () => {
-
   before(() => {
     //admin user, group and device
-    cy.testCreateUserGroupAndDevice("gsGroupAdmin", "gsGroup", "gsCamera").then(() => {
-    });
+    cy.testCreateUserGroupAndDevice("gsGroupAdmin", "gsGroup", "gsCamera").then(
+      () => {}
+    );
 
     //2nd group
-    cy.apiGroupAdd("gsGroupAdmin", "gsGroup2").then(() => {
-    });
+    cy.apiGroupAdd("gsGroupAdmin", "gsGroup2").then(() => {});
 
     //2nd device in first group
-    cy.apiDeviceAdd("gsCamera1b","gsGroup").then(() => {
-    });
+    cy.apiDeviceAdd("gsCamera1b", "gsGroup").then(() => {});
 
     //group member for this group
     cy.apiUserAdd("gsGroupMember");
@@ -55,139 +100,254 @@ describe("Groups - add/update/query/remove stations from group", () => {
 
   it.skip("Group admin can add, update, retire and query stations from a group", () => {
     cy.apiGroupAdd("gsGroupAdmin", "gsGroupA");
-    cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroupA", [station1a]).then(() => {
-      expectedStation1a["GroupId"]=getCreds("gsGroupA").id;
-      expectedStation1a["retiredAt"]=null;
-      expectedStation1a["lastUpdatedById"]=getCreds("gsGroupAdmin").id; 
+    cy.apiGroupStationsUpdate("gsGroupAdmin", "gsGroupA", [station1a]).then(
+      () => {
+        expectedStation1a["GroupId"] = getCreds("gsGroupA").id;
+        expectedStation1a["retiredAt"] = null;
+        expectedStation1a["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
 
-      cy.apiGroupsStationsCheck("gsGroupAdmin","gsGroupA",[expectedStation1a],EXCLUDE_CREATED_UPDATED_ID);
-    });
+        cy.apiGroupsStationsCheck(
+          "gsGroupAdmin",
+          "gsGroupA",
+          [expectedStation1a],
+          EXCLUDE_CREATED_UPDATED_ID
+        );
+      }
+    );
 
     //TODO: FAIL - issue 43
-    cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroupA", [station1b]).then(() => {
-      expectedStation1b["GroupId"]=getCreds("gsGroupA").id;
-      expectedStation1b["retiredAt"]=null;
-      expectedStation1b["lastUpdatedById"]=getCreds("gsGroupAdmin").id;
-    
-      cy.apiGroupsStationsCheck("gsGroupAdmin","gsGroupA",[expectedStation1b],EXCLUDE_CREATED_UPDATED_ID);
-    });
+    cy.apiGroupStationsUpdate("gsGroupAdmin", "gsGroupA", [station1b]).then(
+      () => {
+        expectedStation1b["GroupId"] = getCreds("gsGroupA").id;
+        expectedStation1b["retiredAt"] = null;
+        expectedStation1b["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
+
+        cy.apiGroupsStationsCheck(
+          "gsGroupAdmin",
+          "gsGroupA",
+          [expectedStation1b],
+          EXCLUDE_CREATED_UPDATED_ID
+        );
+      }
+    );
 
     //TODO: FAIL - Issue 44
-    cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroupA", []).then(() => {
-      expectedStation1b["GroupId"]=getCreds("gsGroupA").id;
-      expectedStation1b["retiredAt"]=NOT_NULL;
-      expectedStation1b["lastUpdatedById"]=getCreds("gsGroupAdmin").id;
-      cy.apiGroupsStationsCheck("gsGroupAdmin","gsGroupA",[],EXCLUDE_CREATED_UPDATED_ID);
-
+    cy.apiGroupStationsUpdate("gsGroupAdmin", "gsGroupA", []).then(() => {
+      expectedStation1b["GroupId"] = getCreds("gsGroupA").id;
+      expectedStation1b["retiredAt"] = NOT_NULL;
+      expectedStation1b["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
+      cy.apiGroupsStationsCheck(
+        "gsGroupAdmin",
+        "gsGroupA",
+        [],
+        EXCLUDE_CREATED_UPDATED_ID
+      );
     });
-
   });
 
   it("Group member can query but not add, update, retire stations from a group", () => {
     cy.log("Add a station as admin to test with");
-    cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroup", [station1a]).then(() => {
-      expectedStation1a["GroupId"]=getCreds("gsGroup").id;
-      expectedStation1a["retiredAt"]=null;
-      expectedStation1a["lastUpdatedById"]=getCreds("gsGroupAdmin").id;
+    cy.apiGroupStationsUpdate("gsGroupAdmin", "gsGroup", [station1a]).then(
+      () => {
+        expectedStation1a["GroupId"] = getCreds("gsGroup").id;
+        expectedStation1a["retiredAt"] = null;
+        expectedStation1a["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
 
-      cy.log("Check member can view station");
-      cy.apiGroupsStationsCheck("gsGroupMember","gsGroup",[expectedStation1a],EXCLUDE_CREATED_UPDATED_ID);
+        cy.log("Check member can view station");
+        cy.apiGroupsStationsCheck(
+          "gsGroupMember",
+          "gsGroup",
+          [expectedStation1a],
+          EXCLUDE_CREATED_UPDATED_ID
+        );
 
-      cy.log("Check member cannot add a station");
-      cy.apiGroupStationsUpdate("gsGroupMember","gsGroup", [station2a],undefined,HTTP_Forbidden).then(() => {
-        //station not added
-        cy.apiGroupsStationsCheck("gsGroupMember","gsGroup",[expectedStation1a],EXCLUDE_CREATED_UPDATED_ID);
-      });
+        cy.log("Check member cannot add a station");
+        cy.apiGroupStationsUpdate(
+          "gsGroupMember",
+          "gsGroup",
+          [station2a],
+          undefined,
+          HTTP_Forbidden
+        ).then(() => {
+          //station not added
+          cy.apiGroupsStationsCheck(
+            "gsGroupMember",
+            "gsGroup",
+            [expectedStation1a],
+            EXCLUDE_CREATED_UPDATED_ID
+          );
+        });
 
-      cy.log("Check member cannot update a station");
-      cy.apiGroupStationsUpdate("gsGroupMember","gsGroup", [station1b],undefined,HTTP_Forbidden).then(() => {
-        //station not added
-        cy.apiGroupsStationsCheck("gsGroupMember","gsGroup",[expectedStation1a],EXCLUDE_CREATED_UPDATED_ID);
-      });
+        cy.log("Check member cannot update a station");
+        cy.apiGroupStationsUpdate(
+          "gsGroupMember",
+          "gsGroup",
+          [station1b],
+          undefined,
+          HTTP_Forbidden
+        ).then(() => {
+          //station not added
+          cy.apiGroupsStationsCheck(
+            "gsGroupMember",
+            "gsGroup",
+            [expectedStation1a],
+            EXCLUDE_CREATED_UPDATED_ID
+          );
+        });
 
-      cy.log("Check member cannot retire a station");
-      cy.apiGroupStationsUpdate("gsGroupMember","gsGroup", [],undefined,HTTP_Forbidden).then(() => {
-        //station not retired
-        cy.apiGroupsStationsCheck("gsGroupMember","gsGroup",[expectedStation1a],EXCLUDE_CREATED_UPDATED_ID);
-      });
-    });
+        cy.log("Check member cannot retire a station");
+        cy.apiGroupStationsUpdate(
+          "gsGroupMember",
+          "gsGroup",
+          [],
+          undefined,
+          HTTP_Forbidden
+        ).then(() => {
+          //station not retired
+          cy.apiGroupsStationsCheck(
+            "gsGroupMember",
+            "gsGroup",
+            [expectedStation1a],
+            EXCLUDE_CREATED_UPDATED_ID
+          );
+        });
+      }
+    );
   });
 
   it("Non group members cannot add, update, retire or query stations", () => {
-     cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroup", [station1a]).then(() => {
-      expectedStation1a["GroupId"]=getCreds("gsGroup").id;
-      expectedStation1a["retiredAt"]=null;
-      expectedStation1a["lastUpdatedById"]=getCreds("gsGroupAdmin").id;
+    cy.apiGroupStationsUpdate("gsGroupAdmin", "gsGroup", [station1a]).then(
+      () => {
+        expectedStation1a["GroupId"] = getCreds("gsGroup").id;
+        expectedStation1a["retiredAt"] = null;
+        expectedStation1a["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
 
-      cy.log("Check non-member cannot view station");
-      cy.apiGroupsStationsCheck("gsTestUser","gsGroup",[],null,HTTP_Forbidden);
+        cy.log("Check non-member cannot view station");
+        cy.apiGroupsStationsCheck(
+          "gsTestUser",
+          "gsGroup",
+          [],
+          null,
+          HTTP_Forbidden
+        );
 
-      cy.log("Check non-member cannot add a station");
-      cy.apiGroupStationsUpdate("gsTestUser","gsGroup", [station2a],undefined,HTTP_Forbidden).then(() => {
-        //station not added
-        cy.apiGroupsStationsCheck("gsGroupAdmin","gsGroup",[expectedStation1a],EXCLUDE_CREATED_UPDATED_ID);
-      });
+        cy.log("Check non-member cannot add a station");
+        cy.apiGroupStationsUpdate(
+          "gsTestUser",
+          "gsGroup",
+          [station2a],
+          undefined,
+          HTTP_Forbidden
+        ).then(() => {
+          //station not added
+          cy.apiGroupsStationsCheck(
+            "gsGroupAdmin",
+            "gsGroup",
+            [expectedStation1a],
+            EXCLUDE_CREATED_UPDATED_ID
+          );
+        });
 
-      cy.log("Check non-member cannot update a station");
-      cy.apiGroupStationsUpdate("gsTestUser","gsGroup", [station1b],undefined,HTTP_Forbidden).then(() => {
-        //station not added
-        cy.apiGroupsStationsCheck("gsGroupAdmin","gsGroup",[expectedStation1a],EXCLUDE_CREATED_UPDATED_ID);
-      });
+        cy.log("Check non-member cannot update a station");
+        cy.apiGroupStationsUpdate(
+          "gsTestUser",
+          "gsGroup",
+          [station1b],
+          undefined,
+          HTTP_Forbidden
+        ).then(() => {
+          //station not added
+          cy.apiGroupsStationsCheck(
+            "gsGroupAdmin",
+            "gsGroup",
+            [expectedStation1a],
+            EXCLUDE_CREATED_UPDATED_ID
+          );
+        });
 
-      cy.log("Check non-member cannot retire a station");
-      cy.apiGroupStationsUpdate("gsTestUser","gsGroup", [],undefined,HTTP_Forbidden).then(() => {
-        //station not retired
-        cy.apiGroupsStationsCheck("gsGroupAdmin","gsGroup",[expectedStation1a],EXCLUDE_CREATED_UPDATED_ID);
-      });
-    });
-
+        cy.log("Check non-member cannot retire a station");
+        cy.apiGroupStationsUpdate(
+          "gsTestUser",
+          "gsGroup",
+          [],
+          undefined,
+          HTTP_Forbidden
+        ).then(() => {
+          //station not retired
+          cy.apiGroupsStationsCheck(
+            "gsGroupAdmin",
+            "gsGroup",
+            [expectedStation1a],
+            EXCLUDE_CREATED_UPDATED_ID
+          );
+        });
+      }
+    );
   });
 
   it.skip("Multiple stations supported", () => {
     cy.apiGroupAdd("gsGroupAdmin", "gsGroupD");
 
     cy.log("Add two stations");
-    cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroupD", [station1a, station2a]).then(() => {
-      expectedStation1a["GroupId"]=getCreds("gsGroupD").id;
-      expectedStation1a["retiredAt"]=null;
-      expectedStation1a["lastUpdatedById"]=getCreds("gsGroupAdmin").id;
-      expectedStation2a["GroupId"]=getCreds("gsGroupD").id;
-      expectedStation2a["retiredAt"]=null;
-      expectedStation2a["lastUpdatedById"]=getCreds("gsGroupAdmin").id;
-  
-      //stations added
-      cy.apiGroupsStationsCheck("gsGroupAdmin","gsGroupD",[expectedStation1a, expectedStation2a],EXCLUDE_CREATED_UPDATED_ID);
+    cy.apiGroupStationsUpdate("gsGroupAdmin", "gsGroupD", [
+      station1a,
+      station2a,
+    ]).then(() => {
+      expectedStation1a["GroupId"] = getCreds("gsGroupD").id;
+      expectedStation1a["retiredAt"] = null;
+      expectedStation1a["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
+      expectedStation2a["GroupId"] = getCreds("gsGroupD").id;
+      expectedStation2a["retiredAt"] = null;
+      expectedStation2a["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
 
+      //stations added
+      cy.apiGroupsStationsCheck(
+        "gsGroupAdmin",
+        "gsGroupD",
+        [expectedStation1a, expectedStation2a],
+        EXCLUDE_CREATED_UPDATED_ID
+      );
     });
 
     //TODO Fails =: Issue 43
     cy.log("update two stations");
-    cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroupD", [station1b, station2b]).then(() => {
-      expectedStation1b["GroupId"]=getCreds("gsGroupD").id;
-      expectedStation1b["retiredAt"]=null;
-      expectedStation1b["lastUpdatedById"]=getCreds("gsGroupAdmin").id;
-      expectedStation2b["GroupId"]=getCreds("gsGroupD").id;
-      expectedStation2b["retiredAt"]=null;
-      expectedStation2b["lastUpdatedById"]=getCreds("gsGroupAdmin").id;
-   
+    cy.apiGroupStationsUpdate("gsGroupAdmin", "gsGroupD", [
+      station1b,
+      station2b,
+    ]).then(() => {
+      expectedStation1b["GroupId"] = getCreds("gsGroupD").id;
+      expectedStation1b["retiredAt"] = null;
+      expectedStation1b["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
+      expectedStation2b["GroupId"] = getCreds("gsGroupD").id;
+      expectedStation2b["retiredAt"] = null;
+      expectedStation2b["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
+
       //stations updated
-      cy.apiGroupsStationsCheck("gsGroupAdmin","gsGroupD",[expectedStation1b, expectedStation2b],EXCLUDE_CREATED_UPDATED_ID);
-   
+      cy.apiGroupsStationsCheck(
+        "gsGroupAdmin",
+        "gsGroupD",
+        [expectedStation1b, expectedStation2b],
+        EXCLUDE_CREATED_UPDATED_ID
+      );
     });
 
     //TODO: FAILS: Issue 44
     cy.log("retire two stations");
-    cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroupD", []).then(() => {
-      expectedStation1b["GroupId"]=getCreds("gsGroupD").id;
-      expectedStation1b["retiredAt"]=NOT_NULL;
-      expectedStation1b["lastUpdatedById"]=getCreds("gsGroupAdmin").id;
-      expectedStation2b["GroupId"]=getCreds("gsGroupD").id;
-      expectedStation2b["retiredAt"]=NOT_NULL;
-      expectedStation2b["lastUpdatedById"]=getCreds("gsGroupAdmin").id;
+    cy.apiGroupStationsUpdate("gsGroupAdmin", "gsGroupD", []).then(() => {
+      expectedStation1b["GroupId"] = getCreds("gsGroupD").id;
+      expectedStation1b["retiredAt"] = NOT_NULL;
+      expectedStation1b["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
+      expectedStation2b["GroupId"] = getCreds("gsGroupD").id;
+      expectedStation2b["retiredAt"] = NOT_NULL;
+      expectedStation2b["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
 
       //stations retired
-      cy.apiGroupsStationsCheck("gsGroupAdmin","gsGroupD",[expectedStation1b, expectedStation2b],EXCLUDE_CREATED_UPDATED_ID);
-
+      cy.apiGroupsStationsCheck(
+        "gsGroupAdmin",
+        "gsGroupD",
+        [expectedStation1b, expectedStation2b],
+        EXCLUDE_CREATED_UPDATED_ID
+      );
     });
   });
 
@@ -199,108 +359,220 @@ describe("Groups - add/update/query/remove stations from group", () => {
     //cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroupE", [station1a]);
     cy.log("Add and update station at same time");
 
-    cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroupE", [station1b, station2b]).then(() => {
-      expectedStation1b["GroupId"]=getCreds("gsGroupE").id;
-      expectedStation1b["retiredAt"]=null;
-      expectedStation1b["lastUpdatedById"]=getCreds("gsGroupAdmin").id;
-      expectedStation2b["GroupId"]=getCreds("gsGroupE").id;
-      expectedStation2b["retiredAt"]=null;
-      expectedStation2b["lastUpdatedById"]=getCreds("gsGroupAdmin").id;
+    cy.apiGroupStationsUpdate("gsGroupAdmin", "gsGroupE", [
+      station1b,
+      station2b,
+    ]).then(() => {
+      expectedStation1b["GroupId"] = getCreds("gsGroupE").id;
+      expectedStation1b["retiredAt"] = null;
+      expectedStation1b["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
+      expectedStation2b["GroupId"] = getCreds("gsGroupE").id;
+      expectedStation2b["retiredAt"] = null;
+      expectedStation2b["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
 
       //stations updated and added
-      cy.apiGroupsStationsCheck("gsGroupAdmin","gsGroupE",[expectedStation1b, expectedStation2b],EXCLUDE_CREATED_UPDATED_ID);
+      cy.apiGroupsStationsCheck(
+        "gsGroupAdmin",
+        "gsGroupE",
+        [expectedStation1b, expectedStation2b],
+        EXCLUDE_CREATED_UPDATED_ID
+      );
     });
-
 
     cy.log("retire a station");
-    cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroupE", [station1b]).then(() => {
-      expectedStation1b["GroupId"]=getCreds("gsGroupE").id;
-      expectedStation1b["retiredAt"]=null;
-      expectedStation1b["lastUpdatedById"]=getCreds("gsGroupAdmin").id;
-      expectedStation2b["GroupId"]=getCreds("gsGroupE").id;
-      expectedStation2b["retiredAt"]=NOT_NULL;
-      expectedStation2b["lastUpdatedById"]=getCreds("gsGroupAdmin").id;
-  
-      //stations deleted
-      cy.apiGroupsStationsCheck("gsGroupAdmin","gsGroupE",[expectedStation1b,expectedStation2b],EXCLUDE_CREATED_UPDATED_ID);
-    });
+    cy.apiGroupStationsUpdate("gsGroupAdmin", "gsGroupE", [station1b]).then(
+      () => {
+        expectedStation1b["GroupId"] = getCreds("gsGroupE").id;
+        expectedStation1b["retiredAt"] = null;
+        expectedStation1b["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
+        expectedStation2b["GroupId"] = getCreds("gsGroupE").id;
+        expectedStation2b["retiredAt"] = NOT_NULL;
+        expectedStation2b["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
+
+        //stations deleted
+        cy.apiGroupsStationsCheck(
+          "gsGroupAdmin",
+          "gsGroupE",
+          [expectedStation1b, expectedStation2b],
+          EXCLUDE_CREATED_UPDATED_ID
+        );
+      }
+    );
 
     cy.log("retire and add a station");
-    cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroupE", [station3a]).then(() => {
-      expectedStation1b["GroupId"]=getCreds("gsGroupE").id;
-      expectedStation1b["retiredAt"]=NOT_NULL;
-      expectedStation1b["lastUpdatedById"]=getCreds("gsGroupAdmin").id;
-      expectedStation2b["GroupId"]=getCreds("gsGroupE").id;
-      expectedStation2b["retiredAt"]=NOT_NULL;
-      expectedStation2b["lastUpdatedById"]=getCreds("gsGroupAdmin").id;
-      expectedStation3a["GroupId"]=getCreds("gsGroupE").id;
-      expectedStation3a["retiredAt"]=null;
-      expectedStation3a["lastUpdatedById"]=getCreds("gsGroupAdmin").id;
+    cy.apiGroupStationsUpdate("gsGroupAdmin", "gsGroupE", [station3a]).then(
+      () => {
+        expectedStation1b["GroupId"] = getCreds("gsGroupE").id;
+        expectedStation1b["retiredAt"] = NOT_NULL;
+        expectedStation1b["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
+        expectedStation2b["GroupId"] = getCreds("gsGroupE").id;
+        expectedStation2b["retiredAt"] = NOT_NULL;
+        expectedStation2b["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
+        expectedStation3a["GroupId"] = getCreds("gsGroupE").id;
+        expectedStation3a["retiredAt"] = null;
+        expectedStation3a["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
 
-      //stations deleted and added
-      cy.apiGroupsStationsCheck("gsGroupAdmin","gsGroupE",[expectedStation1b, expectedStation2b, expectedStation3a],EXCLUDE_CREATED_UPDATED_ID);
-    });
-
-
+        //stations deleted and added
+        cy.apiGroupsStationsCheck(
+          "gsGroupAdmin",
+          "gsGroupE",
+          [expectedStation1b, expectedStation2b, expectedStation3a],
+          EXCLUDE_CREATED_UPDATED_ID
+        );
+      }
+    );
   });
 
   it("Invalid group handled correctly", () => {
-    cy.apiGroupStationsUpdate("gsGroupAdmin","ThisGroupDoesNotExist", [station3a], undefined, HTTP_Unprocessable);
-    cy.apiGroupsStationsCheck("gsGroupAdmin","ThisGroupDoesNotExist", [], undefined, HTTP_Unprocessable);
+    cy.apiGroupStationsUpdate(
+      "gsGroupAdmin",
+      "ThisGroupDoesNotExist",
+      [station3a],
+      undefined,
+      HTTP_Unprocessable
+    );
+    cy.apiGroupsStationsCheck(
+      "gsGroupAdmin",
+      "ThisGroupDoesNotExist",
+      [],
+      undefined,
+      HTTP_Unprocessable
+    );
   });
 
   it("Invalid stations parameters handled correctly", () => {
-    let badStation:ApiStationData={name: "hello", lat: null, lng: 172};
-    cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroup",[badStation],undefined,HTTP_Unprocessable);
+    let badStation: ApiStationData = { name: "hello", lat: null, lng: 172 };
+    cy.apiGroupStationsUpdate(
+      "gsGroupAdmin",
+      "gsGroup",
+      [badStation],
+      undefined,
+      HTTP_Unprocessable
+    );
 
-    badStation={name: "hello", lat: "string", lng: 172};
-    cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroup",[badStation],undefined,HTTP_Unprocessable);
+    badStation = { name: "hello", lat: "string", lng: 172 };
+    cy.apiGroupStationsUpdate(
+      "gsGroupAdmin",
+      "gsGroup",
+      [badStation],
+      undefined,
+      HTTP_Unprocessable
+    );
 
-    badStation={name: "hello", lng: 172};
-    cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroup",[badStation],undefined,HTTP_Unprocessable);
+    badStation = { name: "hello", lng: 172 };
+    cy.apiGroupStationsUpdate(
+      "gsGroupAdmin",
+      "gsGroup",
+      [badStation],
+      undefined,
+      HTTP_Unprocessable
+    );
 
-    badStation={name: "hello", lat: -45, lng: null};
-    cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroup",[badStation],undefined,HTTP_Unprocessable);
+    badStation = { name: "hello", lat: -45, lng: null };
+    cy.apiGroupStationsUpdate(
+      "gsGroupAdmin",
+      "gsGroup",
+      [badStation],
+      undefined,
+      HTTP_Unprocessable
+    );
 
-    badStation={name: "hello", lat: -45};
-    cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroup",[badStation],undefined,HTTP_Unprocessable);
+    badStation = { name: "hello", lat: -45 };
+    cy.apiGroupStationsUpdate(
+      "gsGroupAdmin",
+      "gsGroup",
+      [badStation],
+      undefined,
+      HTTP_Unprocessable
+    );
 
-    badStation={name: "hello", lat: -45, lng: "string"};
-    cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroup",[badStation],undefined,HTTP_Unprocessable);
+    badStation = { name: "hello", lat: -45, lng: "string" };
+    cy.apiGroupStationsUpdate(
+      "gsGroupAdmin",
+      "gsGroup",
+      [badStation],
+      undefined,
+      HTTP_Unprocessable
+    );
 
-    badStation={name: null, lat: -45, lng: 172};
-    cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroup",[badStation],undefined,HTTP_Unprocessable);
+    badStation = { name: null, lat: -45, lng: 172 };
+    cy.apiGroupStationsUpdate(
+      "gsGroupAdmin",
+      "gsGroup",
+      [badStation],
+      undefined,
+      HTTP_Unprocessable
+    );
 
-    badStation={lat: -45, lng: "string"};
-    cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroup",[badStation],undefined,HTTP_Unprocessable);
+    badStation = { lat: -45, lng: "string" };
+    cy.apiGroupStationsUpdate(
+      "gsGroupAdmin",
+      "gsGroup",
+      [badStation],
+      undefined,
+      HTTP_Unprocessable
+    );
 
-    badStation={name: "hello", lat: -45, lng: 172, randomParameter: true};
-    //unexpected parameters ignored 
+    badStation = { name: "hello", lat: -45, lng: 172, randomParameter: true };
+    //unexpected parameters ignored
     //cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroup",[badStation],undefined,HTTP_Unprocessable);
-    cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroup",[badStation],undefined,HTTP_OK200);
+    cy.apiGroupStationsUpdate(
+      "gsGroupAdmin",
+      "gsGroup",
+      [badStation],
+      undefined,
+      HTTP_OK200
+    );
 
     //but a valid one still works
-    cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroup",[station1a],undefined,HTTP_OK200);
+    cy.apiGroupStationsUpdate(
+      "gsGroupAdmin",
+      "gsGroup",
+      [station1a],
+      undefined,
+      HTTP_OK200
+    );
   });
 
   it("From date validated correctly", () => {
-    let timestamp = new Date().toISOString();
+    const timestamp = new Date().toISOString();
     cy.log("from date timestamp accepted");
-    cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroup",[station1a],timestamp,HTTP_OK200);
+    cy.apiGroupStationsUpdate(
+      "gsGroupAdmin",
+      "gsGroup",
+      [station1a],
+      timestamp,
+      HTTP_OK200
+    );
 
     cy.log("from date absent accepted");
-    cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroup",[station1a],undefined,HTTP_OK200);
+    cy.apiGroupStationsUpdate(
+      "gsGroupAdmin",
+      "gsGroup",
+      [station1a],
+      undefined,
+      HTTP_OK200
+    );
 
     cy.log("from date blank rejected");
-    cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroup",[station1a],"",HTTP_Unprocessable);
+    cy.apiGroupStationsUpdate(
+      "gsGroupAdmin",
+      "gsGroup",
+      [station1a],
+      "",
+      HTTP_Unprocessable
+    );
 
     cy.log("malformed from date rejected");
-    cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroup",[station1a],"ThisIsNotADate",HTTP_Unprocessable);
+    cy.apiGroupStationsUpdate(
+      "gsGroupAdmin",
+      "gsGroup",
+      [station1a],
+      "ThisIsNotADate",
+      HTTP_Unprocessable
+    );
   });
 
   //Mapping of recording to stations tested in the recordings section
   //Application of fromDate to existing recordings tested in the recordings section
-
-
 });
-

--- a/integration-tests/cypress/integration/api/groups/groups_stations.ts
+++ b/integration-tests/cypress/integration/api/groups/groups_stations.ts
@@ -1,0 +1,306 @@
+/// <reference path="../../../support/index.d.ts" />
+
+import { ApiStationData, ApiStationDataReturned } from "../../../commands/types";
+import { getCreds } from "../../../commands/server";
+
+import { HTTP_OK200 } from "../../../commands/constants";
+import { HTTP_Forbidden } from "../../../commands/constants";
+import { HTTP_Unprocessable } from "../../../commands/constants";
+import { NOT_NULL } from "../../../commands/constants";
+
+const ADMIN=true;
+const NOT_ADMIN=false;
+const EXCLUDE_CREATED_UPDATED_ID=["[].createdAt","[].updatedAt","[].id"];
+
+let station1a={name: "station1", lat: -45.1, lng: 172.1};
+let station1b={name: "station1", lat: -45.2, lng: 172.1};
+let station2a={name: "station2", lat: -45.1, lng: 172.2};
+let station2b={name: "station2", lat: -45.2, lng: 172.2};
+let station3a={name: "station3", lat: -45.1, lng: 172.3};
+
+//TODO: These coordinates are back to front.  Issue 73. Reverse once database & API are corrected. Should be X,Y
+let expectedStation1a:ApiStationDataReturned={ id:0, name: "station1", location:{type: "Point", coordinates:  [-45.1,172.1]}, lastUpdatedById: 0, createdAt: null, retiredAt: null, updatedAt: null, GroupId: null};
+let expectedStation1b:ApiStationDataReturned={ id:0, name: "station1", location:{type: "Point", coordinates:  [-45.2,172.1]}, lastUpdatedById: 0, createdAt: null, retiredAt: null, updatedAt: null, GroupId: null};
+let expectedStation2a:ApiStationDataReturned={ id:0, name: "station2", location:{type: "Point", coordinates:  [-45.1,172.2]}, lastUpdatedById: 0, createdAt: null, retiredAt: null, updatedAt: null, GroupId: null};
+let expectedStation2b:ApiStationDataReturned={ id:0, name: "station2", location:{type: "Point", coordinates:  [-45.2,172.2]}, lastUpdatedById: 0, createdAt: null, retiredAt: null, updatedAt: null, GroupId: null};
+let expectedStation3a:ApiStationDataReturned={ id:0, name: "station3", location:{type: "Point", coordinates:  [-45.1,172.3]}, lastUpdatedById: 0, createdAt: null, retiredAt: null, updatedAt: null, GroupId: null};
+
+
+describe("Groups - add/update/query/remove stations from group", () => {
+
+  before(() => {
+    //admin user, group and device
+    cy.apiCreateUserGroupAndDevice("gsGroupAdmin", "gsGroup", "gsCamera").then(() => {
+    });
+
+    //2nd group
+    cy.apiGroupAdd("gsGroupAdmin", "gsGroup2").then(() => {
+    });
+
+    //2nd device in first group
+    cy.apiCreateDevice("gsCamera1b","gsGroup").then(() => {
+    });
+
+    //group member for this group
+    cy.apiCreateUser("gsGroupMember");
+    cy.apiGroupUserAdd("gsGroupAdmin", "gsGroupMember", "gsGroup", NOT_ADMIN);
+
+    //device admin for 1st device
+    cy.apiCreateUser("gsDeviceAdmin");
+    cy.apiAddUserToDevice("gsGroupAdmin", "gsDeviceAdmin", "gsCamera", ADMIN);
+
+    // test users
+    cy.apiCreateUser("gsTestUser");
+  });
+
+  it.skip("Group admin can add, update, retire and query stations from a group", () => {
+    cy.apiGroupAdd("gsGroupAdmin", "gsGroupA");
+    cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroupA", [station1a]).then(() => {
+      expectedStation1a["GroupId"]=getCreds("gsGroupA").id;
+      expectedStation1a["retiredAt"]=null;
+      expectedStation1a["lastUpdatedById"]=getCreds("gsGroupAdmin").id; 
+
+      cy.apiGroupsStationsCheck("gsGroupAdmin","gsGroupA",[expectedStation1a],EXCLUDE_CREATED_UPDATED_ID);
+    });
+
+    //TODO: FAIL - issue 43
+    cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroupA", [station1b]).then(() => {
+      expectedStation1b["GroupId"]=getCreds("gsGroupA").id;
+      expectedStation1b["retiredAt"]=null;
+      expectedStation1b["lastUpdatedById"]=getCreds("gsGroupAdmin").id;
+    
+      cy.apiGroupsStationsCheck("gsGroupAdmin","gsGroupA",[expectedStation1b],EXCLUDE_CREATED_UPDATED_ID);
+    });
+
+    //TODO: FAIL - Issue 44
+    cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroupA", []).then(() => {
+      expectedStation1b["GroupId"]=getCreds("gsGroupA").id;
+      expectedStation1b["retiredAt"]=NOT_NULL;
+      expectedStation1b["lastUpdatedById"]=getCreds("gsGroupAdmin").id;
+      cy.apiGroupsStationsCheck("gsGroupAdmin","gsGroupA",[],EXCLUDE_CREATED_UPDATED_ID);
+
+    });
+
+  });
+
+  it("Group member can query but not add, update, retire stations from a group", () => {
+    cy.log("Add a station as admin to test with");
+    cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroup", [station1a]).then(() => {
+      expectedStation1a["GroupId"]=getCreds("gsGroup").id;
+      expectedStation1a["retiredAt"]=null;
+      expectedStation1a["lastUpdatedById"]=getCreds("gsGroupAdmin").id;
+
+      cy.log("Check member can view station");
+      cy.apiGroupsStationsCheck("gsGroupMember","gsGroup",[expectedStation1a],EXCLUDE_CREATED_UPDATED_ID);
+
+      cy.log("Check member cannot add a station");
+      cy.apiGroupsStationsUpdate("gsGroupMember","gsGroup", [station2a],undefined,HTTP_Forbidden).then(() => {
+        //station not added
+        cy.apiGroupsStationsCheck("gsGroupMember","gsGroup",[expectedStation1a],EXCLUDE_CREATED_UPDATED_ID);
+      });
+
+      cy.log("Check member cannot update a station");
+      cy.apiGroupsStationsUpdate("gsGroupMember","gsGroup", [station1b],undefined,HTTP_Forbidden).then(() => {
+        //station not added
+        cy.apiGroupsStationsCheck("gsGroupMember","gsGroup",[expectedStation1a],EXCLUDE_CREATED_UPDATED_ID);
+      });
+
+      cy.log("Check member cannot retire a station");
+      cy.apiGroupsStationsUpdate("gsGroupMember","gsGroup", [],undefined,HTTP_Forbidden).then(() => {
+        //station not retired
+        cy.apiGroupsStationsCheck("gsGroupMember","gsGroup",[expectedStation1a],EXCLUDE_CREATED_UPDATED_ID);
+      });
+    });
+  });
+
+  it("Non group members cannot add, update, retire or query stations", () => {
+     cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroup", [station1a]).then(() => {
+      expectedStation1a["GroupId"]=getCreds("gsGroup").id;
+      expectedStation1a["retiredAt"]=null;
+      expectedStation1a["lastUpdatedById"]=getCreds("gsGroupAdmin").id;
+
+      cy.log("Check non-member cannot view station");
+      cy.apiGroupsStationsCheck("gsTestUser","gsGroup",[],null,HTTP_Forbidden);
+
+      cy.log("Check non-member cannot add a station");
+      cy.apiGroupsStationsUpdate("gsTestUser","gsGroup", [station2a],undefined,HTTP_Forbidden).then(() => {
+        //station not added
+        cy.apiGroupsStationsCheck("gsGroupAdmin","gsGroup",[expectedStation1a],EXCLUDE_CREATED_UPDATED_ID);
+      });
+
+      cy.log("Check non-member cannot update a station");
+      cy.apiGroupsStationsUpdate("gsTestUser","gsGroup", [station1b],undefined,HTTP_Forbidden).then(() => {
+        //station not added
+        cy.apiGroupsStationsCheck("gsGroupAdmin","gsGroup",[expectedStation1a],EXCLUDE_CREATED_UPDATED_ID);
+      });
+
+      cy.log("Check non-member cannot retire a station");
+      cy.apiGroupsStationsUpdate("gsTestUser","gsGroup", [],undefined,HTTP_Forbidden).then(() => {
+        //station not retired
+        cy.apiGroupsStationsCheck("gsGroupAdmin","gsGroup",[expectedStation1a],EXCLUDE_CREATED_UPDATED_ID);
+      });
+    });
+
+  });
+
+  it.skip("Multiple stations supported", () => {
+    cy.apiGroupAdd("gsGroupAdmin", "gsGroupD");
+
+    cy.log("Add two stations");
+    cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroupD", [station1a, station2a]).then(() => {
+      expectedStation1a["GroupId"]=getCreds("gsGroupD").id;
+      expectedStation1a["retiredAt"]=null;
+      expectedStation1a["lastUpdatedById"]=getCreds("gsGroupAdmin").id;
+      expectedStation2a["GroupId"]=getCreds("gsGroupD").id;
+      expectedStation2a["retiredAt"]=null;
+      expectedStation2a["lastUpdatedById"]=getCreds("gsGroupAdmin").id;
+  
+      //stations added
+      cy.apiGroupsStationsCheck("gsGroupAdmin","gsGroupD",[expectedStation1a, expectedStation2a],EXCLUDE_CREATED_UPDATED_ID);
+
+    });
+
+    //TODO Fails =: Issue 43
+    cy.log("update two stations");
+    cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroupD", [station1b, station2b]).then(() => {
+      expectedStation1b["GroupId"]=getCreds("gsGroupD").id;
+      expectedStation1b["retiredAt"]=null;
+      expectedStation1b["lastUpdatedById"]=getCreds("gsGroupAdmin").id;
+      expectedStation2b["GroupId"]=getCreds("gsGroupD").id;
+      expectedStation2b["retiredAt"]=null;
+      expectedStation2b["lastUpdatedById"]=getCreds("gsGroupAdmin").id;
+   
+      //stations updated
+      cy.apiGroupsStationsCheck("gsGroupAdmin","gsGroupD",[expectedStation1b, expectedStation2b],EXCLUDE_CREATED_UPDATED_ID);
+   
+    });
+
+    //TODO: FAILS: Issue 44
+    cy.log("retire two stations");
+    cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroupD", []).then(() => {
+      expectedStation1b["GroupId"]=getCreds("gsGroupD").id;
+      expectedStation1b["retiredAt"]=NOT_NULL;
+      expectedStation1b["lastUpdatedById"]=getCreds("gsGroupAdmin").id;
+      expectedStation2b["GroupId"]=getCreds("gsGroupD").id;
+      expectedStation2b["retiredAt"]=NOT_NULL;
+      expectedStation2b["lastUpdatedById"]=getCreds("gsGroupAdmin").id;
+
+      //stations retired
+      cy.apiGroupsStationsCheck("gsGroupAdmin","gsGroupD",[expectedStation1b, expectedStation2b],EXCLUDE_CREATED_UPDATED_ID);
+
+    });
+  });
+
+  it("Mix of add/update/retire supported", () => {
+    cy.apiGroupAdd("gsGroupAdmin", "gsGroupE");
+
+    //add a station to test with
+    ////TODO: Issue 44. enabled when fixed - not adding as later update will fail
+    //cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroupE", [station1a]);
+    cy.log("Add and update station at same time");
+
+    cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroupE", [station1b, station2b]).then(() => {
+      expectedStation1b["GroupId"]=getCreds("gsGroupE").id;
+      expectedStation1b["retiredAt"]=null;
+      expectedStation1b["lastUpdatedById"]=getCreds("gsGroupAdmin").id;
+      expectedStation2b["GroupId"]=getCreds("gsGroupE").id;
+      expectedStation2b["retiredAt"]=null;
+      expectedStation2b["lastUpdatedById"]=getCreds("gsGroupAdmin").id;
+
+      //stations updated and added
+      cy.apiGroupsStationsCheck("gsGroupAdmin","gsGroupE",[expectedStation1b, expectedStation2b],EXCLUDE_CREATED_UPDATED_ID);
+    });
+
+
+    cy.log("retire a station");
+    cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroupE", [station1b]).then(() => {
+      expectedStation1b["GroupId"]=getCreds("gsGroupE").id;
+      expectedStation1b["retiredAt"]=null;
+      expectedStation1b["lastUpdatedById"]=getCreds("gsGroupAdmin").id;
+      expectedStation2b["GroupId"]=getCreds("gsGroupE").id;
+      expectedStation2b["retiredAt"]=NOT_NULL;
+      expectedStation2b["lastUpdatedById"]=getCreds("gsGroupAdmin").id;
+  
+      //stations deleted
+      cy.apiGroupsStationsCheck("gsGroupAdmin","gsGroupE",[expectedStation1b,expectedStation2b],EXCLUDE_CREATED_UPDATED_ID);
+    });
+
+    cy.log("retire and add a station");
+    cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroupE", [station3a]).then(() => {
+      expectedStation1b["GroupId"]=getCreds("gsGroupE").id;
+      expectedStation1b["retiredAt"]=NOT_NULL;
+      expectedStation1b["lastUpdatedById"]=getCreds("gsGroupAdmin").id;
+      expectedStation2b["GroupId"]=getCreds("gsGroupE").id;
+      expectedStation2b["retiredAt"]=NOT_NULL;
+      expectedStation2b["lastUpdatedById"]=getCreds("gsGroupAdmin").id;
+      expectedStation3a["GroupId"]=getCreds("gsGroupE").id;
+      expectedStation3a["retiredAt"]=null;
+      expectedStation3a["lastUpdatedById"]=getCreds("gsGroupAdmin").id;
+
+      //stations deleted and added
+      cy.apiGroupsStationsCheck("gsGroupAdmin","gsGroupE",[expectedStation1b, expectedStation2b, expectedStation3a],EXCLUDE_CREATED_UPDATED_ID);
+    });
+
+
+  });
+
+  it("Invalid group handled correctly", () => {
+    cy.apiGroupsStationsUpdate("gsGroupAdmin","ThisGroupDoesNotExist", [station3a], undefined, HTTP_Unprocessable);
+    cy.apiGroupsStationsCheck("gsGroupAdmin","ThisGroupDoesNotExist", [], undefined, HTTP_Unprocessable);
+  });
+
+  it("Invalid stations parameters handled correctly", () => {
+    let badStation:ApiStationData={name: "hello", lat: null, lng: 172};
+    cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroup",[badStation],undefined,HTTP_Unprocessable);
+
+    badStation={name: "hello", lat: "string", lng: 172};
+    cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroup",[badStation],undefined,HTTP_Unprocessable);
+
+    badStation={name: "hello", lng: 172};
+    cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroup",[badStation],undefined,HTTP_Unprocessable);
+
+    badStation={name: "hello", lat: -45, lng: null};
+    cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroup",[badStation],undefined,HTTP_Unprocessable);
+
+    badStation={name: "hello", lat: -45};
+    cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroup",[badStation],undefined,HTTP_Unprocessable);
+
+    badStation={name: "hello", lat: -45, lng: "string"};
+    cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroup",[badStation],undefined,HTTP_Unprocessable);
+
+    badStation={name: null, lat: -45, lng: 172};
+    cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroup",[badStation],undefined,HTTP_Unprocessable);
+
+    badStation={lat: -45, lng: "string"};
+    cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroup",[badStation],undefined,HTTP_Unprocessable);
+
+    badStation={name: "hello", lat: -45, lng: 172, randomParameter: true};
+    //unexpected parameters ignored 
+    //cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroup",[badStation],undefined,HTTP_Unprocessable);
+    cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroup",[badStation],undefined,HTTP_OK200);
+
+    //but a valid one still works
+    cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroup",[station1a],undefined,HTTP_OK200);
+  });
+
+  it("From date validated correctly", () => {
+    let timestamp = new Date().toISOString();
+    cy.log("from date timestamp accepted");
+    cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroup",[station1a],timestamp,HTTP_OK200);
+
+    cy.log("from date absent accepted");
+    cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroup",[station1a],undefined,HTTP_OK200);
+
+    cy.log("from date blank rejected");
+    cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroup",[station1a],"",HTTP_Unprocessable);
+
+    cy.log("malformed from date rejected");
+    cy.apiGroupsStationsUpdate("gsGroupAdmin","gsGroup",[station1a],"ThisIsNotADate",HTTP_Unprocessable);
+  });
+
+  //Mapping of recording to stations tested in the recordings section
+  //Application of fromDate to existing recordings tested in the recordings section
+
+
+});
+

--- a/integration-tests/cypress/integration/api/groups/groups_stations.ts
+++ b/integration-tests/cypress/integration/api/groups/groups_stations.ts
@@ -106,12 +106,7 @@ describe("Groups - add/update/query/remove stations from group", () => {
         expectedStation1a["retiredAt"] = null;
         expectedStation1a["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
 
-        cy.apiGroupsStationsCheck(
-          "gsGroupAdmin",
-          "gsGroupA",
-          [expectedStation1a],
-          EXCLUDE_CREATED_UPDATED_ID
-        );
+        cy.apiGroupsStationsCheck( "gsGroupAdmin", "gsGroupA", [expectedStation1a], EXCLUDE_CREATED_UPDATED_ID);
       }
     );
 
@@ -122,12 +117,7 @@ describe("Groups - add/update/query/remove stations from group", () => {
         expectedStation1b["retiredAt"] = null;
         expectedStation1b["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
 
-        cy.apiGroupsStationsCheck(
-          "gsGroupAdmin",
-          "gsGroupA",
-          [expectedStation1b],
-          EXCLUDE_CREATED_UPDATED_ID
-        );
+        cy.apiGroupsStationsCheck( "gsGroupAdmin", "gsGroupA", [expectedStation1b], EXCLUDE_CREATED_UPDATED_ID);
       }
     );
 
@@ -136,12 +126,7 @@ describe("Groups - add/update/query/remove stations from group", () => {
       expectedStation1b["GroupId"] = getCreds("gsGroupA").id;
       expectedStation1b["retiredAt"] = NOT_NULL;
       expectedStation1b["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
-      cy.apiGroupsStationsCheck(
-        "gsGroupAdmin",
-        "gsGroupA",
-        [],
-        EXCLUDE_CREATED_UPDATED_ID
-      );
+      cy.apiGroupsStationsCheck( "gsGroupAdmin", "gsGroupA", [], EXCLUDE_CREATED_UPDATED_ID);
     });
   });
 
@@ -154,62 +139,24 @@ describe("Groups - add/update/query/remove stations from group", () => {
         expectedStation1a["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
 
         cy.log("Check member can view station");
-        cy.apiGroupsStationsCheck(
-          "gsGroupMember",
-          "gsGroup",
-          [expectedStation1a],
-          EXCLUDE_CREATED_UPDATED_ID
-        );
+        cy.apiGroupsStationsCheck( "gsGroupMember", "gsGroup", [expectedStation1a], EXCLUDE_CREATED_UPDATED_ID);
 
         cy.log("Check member cannot add a station");
-        cy.apiGroupStationsUpdate(
-          "gsGroupMember",
-          "gsGroup",
-          [station2a],
-          undefined,
-          HTTP_Forbidden
-        ).then(() => {
+        cy.apiGroupStationsUpdate( "gsGroupMember", "gsGroup", [station2a], undefined, HTTP_Forbidden).then(() => {
           //station not added
-          cy.apiGroupsStationsCheck(
-            "gsGroupMember",
-            "gsGroup",
-            [expectedStation1a],
-            EXCLUDE_CREATED_UPDATED_ID
-          );
+          cy.apiGroupsStationsCheck( "gsGroupMember", "gsGroup", [expectedStation1a], EXCLUDE_CREATED_UPDATED_ID);
         });
 
         cy.log("Check member cannot update a station");
-        cy.apiGroupStationsUpdate(
-          "gsGroupMember",
-          "gsGroup",
-          [station1b],
-          undefined,
-          HTTP_Forbidden
-        ).then(() => {
+        cy.apiGroupStationsUpdate( "gsGroupMember", "gsGroup", [station1b], undefined, HTTP_Forbidden).then(() => {
           //station not added
-          cy.apiGroupsStationsCheck(
-            "gsGroupMember",
-            "gsGroup",
-            [expectedStation1a],
-            EXCLUDE_CREATED_UPDATED_ID
-          );
+          cy.apiGroupsStationsCheck( "gsGroupMember", "gsGroup", [expectedStation1a], EXCLUDE_CREATED_UPDATED_ID);
         });
 
         cy.log("Check member cannot retire a station");
-        cy.apiGroupStationsUpdate(
-          "gsGroupMember",
-          "gsGroup",
-          [],
-          undefined,
-          HTTP_Forbidden
-        ).then(() => {
+        cy.apiGroupStationsUpdate( "gsGroupMember", "gsGroup", [], undefined, HTTP_Forbidden).then(() => {
           //station not retired
-          cy.apiGroupsStationsCheck(
-            "gsGroupMember",
-            "gsGroup",
-            [expectedStation1a],
-            EXCLUDE_CREATED_UPDATED_ID
-          );
+          cy.apiGroupsStationsCheck( "gsGroupMember", "gsGroup", [expectedStation1a], EXCLUDE_CREATED_UPDATED_ID);
         });
       }
     );
@@ -223,63 +170,24 @@ describe("Groups - add/update/query/remove stations from group", () => {
         expectedStation1a["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
 
         cy.log("Check non-member cannot view station");
-        cy.apiGroupsStationsCheck(
-          "gsTestUser",
-          "gsGroup",
-          [],
-          null,
-          HTTP_Forbidden
-        );
+        cy.apiGroupsStationsCheck( "gsTestUser", "gsGroup", [], null, HTTP_Forbidden);
 
         cy.log("Check non-member cannot add a station");
-        cy.apiGroupStationsUpdate(
-          "gsTestUser",
-          "gsGroup",
-          [station2a],
-          undefined,
-          HTTP_Forbidden
-        ).then(() => {
+        cy.apiGroupStationsUpdate( "gsTestUser", "gsGroup", [station2a], undefined, HTTP_Forbidden).then(() => {
           //station not added
-          cy.apiGroupsStationsCheck(
-            "gsGroupAdmin",
-            "gsGroup",
-            [expectedStation1a],
-            EXCLUDE_CREATED_UPDATED_ID
-          );
+          cy.apiGroupsStationsCheck( "gsGroupAdmin", "gsGroup", [expectedStation1a], EXCLUDE_CREATED_UPDATED_ID);
         });
 
         cy.log("Check non-member cannot update a station");
-        cy.apiGroupStationsUpdate(
-          "gsTestUser",
-          "gsGroup",
-          [station1b],
-          undefined,
-          HTTP_Forbidden
-        ).then(() => {
+        cy.apiGroupStationsUpdate( "gsTestUser", "gsGroup", [station1b], undefined, HTTP_Forbidden).then(() => {
           //station not added
-          cy.apiGroupsStationsCheck(
-            "gsGroupAdmin",
-            "gsGroup",
-            [expectedStation1a],
-            EXCLUDE_CREATED_UPDATED_ID
-          );
+          cy.apiGroupsStationsCheck( "gsGroupAdmin", "gsGroup", [expectedStation1a], EXCLUDE_CREATED_UPDATED_ID);
         });
 
         cy.log("Check non-member cannot retire a station");
-        cy.apiGroupStationsUpdate(
-          "gsTestUser",
-          "gsGroup",
-          [],
-          undefined,
-          HTTP_Forbidden
-        ).then(() => {
+        cy.apiGroupStationsUpdate( "gsTestUser", "gsGroup", [], undefined, HTTP_Forbidden).then(() => {
           //station not retired
-          cy.apiGroupsStationsCheck(
-            "gsGroupAdmin",
-            "gsGroup",
-            [expectedStation1a],
-            EXCLUDE_CREATED_UPDATED_ID
-          );
+          cy.apiGroupsStationsCheck( "gsGroupAdmin", "gsGroup", [expectedStation1a], EXCLUDE_CREATED_UPDATED_ID);
         });
       }
     );
@@ -289,10 +197,7 @@ describe("Groups - add/update/query/remove stations from group", () => {
     cy.apiGroupAdd("gsGroupAdmin", "gsGroupD");
 
     cy.log("Add two stations");
-    cy.apiGroupStationsUpdate("gsGroupAdmin", "gsGroupD", [
-      station1a,
-      station2a,
-    ]).then(() => {
+    cy.apiGroupStationsUpdate("gsGroupAdmin", "gsGroupD", [ station1a, station2a, ]).then(() => {
       expectedStation1a["GroupId"] = getCreds("gsGroupD").id;
       expectedStation1a["retiredAt"] = null;
       expectedStation1a["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
@@ -301,20 +206,12 @@ describe("Groups - add/update/query/remove stations from group", () => {
       expectedStation2a["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
 
       //stations added
-      cy.apiGroupsStationsCheck(
-        "gsGroupAdmin",
-        "gsGroupD",
-        [expectedStation1a, expectedStation2a],
-        EXCLUDE_CREATED_UPDATED_ID
-      );
+      cy.apiGroupsStationsCheck( "gsGroupAdmin", "gsGroupD", [expectedStation1a, expectedStation2a], EXCLUDE_CREATED_UPDATED_ID);
     });
 
     //TODO Fails =: Issue 43
     cy.log("update two stations");
-    cy.apiGroupStationsUpdate("gsGroupAdmin", "gsGroupD", [
-      station1b,
-      station2b,
-    ]).then(() => {
+    cy.apiGroupStationsUpdate("gsGroupAdmin", "gsGroupD", [ station1b, station2b, ]).then(() => {
       expectedStation1b["GroupId"] = getCreds("gsGroupD").id;
       expectedStation1b["retiredAt"] = null;
       expectedStation1b["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
@@ -323,12 +220,7 @@ describe("Groups - add/update/query/remove stations from group", () => {
       expectedStation2b["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
 
       //stations updated
-      cy.apiGroupsStationsCheck(
-        "gsGroupAdmin",
-        "gsGroupD",
-        [expectedStation1b, expectedStation2b],
-        EXCLUDE_CREATED_UPDATED_ID
-      );
+      cy.apiGroupsStationsCheck( "gsGroupAdmin", "gsGroupD", [expectedStation1b, expectedStation2b], EXCLUDE_CREATED_UPDATED_ID);
     });
 
     //TODO: FAILS: Issue 44
@@ -342,12 +234,7 @@ describe("Groups - add/update/query/remove stations from group", () => {
       expectedStation2b["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
 
       //stations retired
-      cy.apiGroupsStationsCheck(
-        "gsGroupAdmin",
-        "gsGroupD",
-        [expectedStation1b, expectedStation2b],
-        EXCLUDE_CREATED_UPDATED_ID
-      );
+      cy.apiGroupsStationsCheck( "gsGroupAdmin", "gsGroupD", [expectedStation1b, expectedStation2b], EXCLUDE_CREATED_UPDATED_ID);
     });
   });
 
@@ -359,10 +246,7 @@ describe("Groups - add/update/query/remove stations from group", () => {
     //cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroupE", [station1a]);
     cy.log("Add and update station at same time");
 
-    cy.apiGroupStationsUpdate("gsGroupAdmin", "gsGroupE", [
-      station1b,
-      station2b,
-    ]).then(() => {
+    cy.apiGroupStationsUpdate("gsGroupAdmin", "gsGroupE", [ station1b, station2b, ]).then(() => {
       expectedStation1b["GroupId"] = getCreds("gsGroupE").id;
       expectedStation1b["retiredAt"] = null;
       expectedStation1b["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
@@ -371,12 +255,7 @@ describe("Groups - add/update/query/remove stations from group", () => {
       expectedStation2b["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
 
       //stations updated and added
-      cy.apiGroupsStationsCheck(
-        "gsGroupAdmin",
-        "gsGroupE",
-        [expectedStation1b, expectedStation2b],
-        EXCLUDE_CREATED_UPDATED_ID
-      );
+      cy.apiGroupsStationsCheck( "gsGroupAdmin", "gsGroupE", [expectedStation1b, expectedStation2b], EXCLUDE_CREATED_UPDATED_ID);
     });
 
     cy.log("retire a station");
@@ -390,12 +269,7 @@ describe("Groups - add/update/query/remove stations from group", () => {
         expectedStation2b["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
 
         //stations deleted
-        cy.apiGroupsStationsCheck(
-          "gsGroupAdmin",
-          "gsGroupE",
-          [expectedStation1b, expectedStation2b],
-          EXCLUDE_CREATED_UPDATED_ID
-        );
+        cy.apiGroupsStationsCheck( "gsGroupAdmin", "gsGroupE", [expectedStation1b, expectedStation2b], EXCLUDE_CREATED_UPDATED_ID);
       }
     );
 
@@ -413,164 +287,105 @@ describe("Groups - add/update/query/remove stations from group", () => {
         expectedStation3a["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
 
         //stations deleted and added
-        cy.apiGroupsStationsCheck(
-          "gsGroupAdmin",
-          "gsGroupE",
-          [expectedStation1b, expectedStation2b, expectedStation3a],
-          EXCLUDE_CREATED_UPDATED_ID
-        );
+        cy.apiGroupsStationsCheck( "gsGroupAdmin", "gsGroupE", [expectedStation1b, expectedStation2b, expectedStation3a], EXCLUDE_CREATED_UPDATED_ID);
       }
     );
   });
 
   it("Invalid group handled correctly", () => {
-    cy.apiGroupStationsUpdate(
-      "gsGroupAdmin",
-      "ThisGroupDoesNotExist",
-      [station3a],
-      undefined,
-      HTTP_Unprocessable
-    );
-    cy.apiGroupsStationsCheck(
-      "gsGroupAdmin",
-      "ThisGroupDoesNotExist",
-      [],
-      undefined,
-      HTTP_Unprocessable
-    );
+    cy.apiGroupStationsUpdate( "gsGroupAdmin", "ThisGroupDoesNotExist", [station3a], undefined, HTTP_Unprocessable);
+    cy.apiGroupsStationsCheck( "gsGroupAdmin", "ThisGroupDoesNotExist", [], undefined, HTTP_Unprocessable);
   });
 
   it("Invalid stations parameters handled correctly", () => {
     let badStation: ApiStationData = { name: "hello", lat: null, lng: 172 };
-    cy.apiGroupStationsUpdate(
-      "gsGroupAdmin",
-      "gsGroup",
-      [badStation],
-      undefined,
-      HTTP_Unprocessable
-    );
+    cy.apiGroupStationsUpdate( "gsGroupAdmin", "gsGroup", [badStation], undefined, HTTP_Unprocessable);
 
     badStation = { name: "hello", lat: "string", lng: 172 };
-    cy.apiGroupStationsUpdate(
-      "gsGroupAdmin",
-      "gsGroup",
-      [badStation],
-      undefined,
-      HTTP_Unprocessable
-    );
+    cy.apiGroupStationsUpdate( "gsGroupAdmin", "gsGroup", [badStation], undefined, HTTP_Unprocessable);
 
     badStation = { name: "hello", lng: 172 };
-    cy.apiGroupStationsUpdate(
-      "gsGroupAdmin",
-      "gsGroup",
-      [badStation],
-      undefined,
-      HTTP_Unprocessable
-    );
+    cy.apiGroupStationsUpdate( "gsGroupAdmin", "gsGroup", [badStation], undefined, HTTP_Unprocessable);
 
     badStation = { name: "hello", lat: -45, lng: null };
-    cy.apiGroupStationsUpdate(
-      "gsGroupAdmin",
-      "gsGroup",
-      [badStation],
-      undefined,
-      HTTP_Unprocessable
-    );
+    cy.apiGroupStationsUpdate( "gsGroupAdmin", "gsGroup", [badStation], undefined, HTTP_Unprocessable);
 
     badStation = { name: "hello", lat: -45 };
-    cy.apiGroupStationsUpdate(
-      "gsGroupAdmin",
-      "gsGroup",
-      [badStation],
-      undefined,
-      HTTP_Unprocessable
-    );
+    cy.apiGroupStationsUpdate( "gsGroupAdmin", "gsGroup", [badStation], undefined, HTTP_Unprocessable);
 
     badStation = { name: "hello", lat: -45, lng: "string" };
-    cy.apiGroupStationsUpdate(
-      "gsGroupAdmin",
-      "gsGroup",
-      [badStation],
-      undefined,
-      HTTP_Unprocessable
-    );
+    cy.apiGroupStationsUpdate( "gsGroupAdmin", "gsGroup", [badStation], undefined, HTTP_Unprocessable);
 
     badStation = { name: null, lat: -45, lng: 172 };
-    cy.apiGroupStationsUpdate(
-      "gsGroupAdmin",
-      "gsGroup",
-      [badStation],
-      undefined,
-      HTTP_Unprocessable
-    );
+    cy.apiGroupStationsUpdate( "gsGroupAdmin", "gsGroup", [badStation], undefined, HTTP_Unprocessable);
 
     badStation = { lat: -45, lng: "string" };
-    cy.apiGroupStationsUpdate(
-      "gsGroupAdmin",
-      "gsGroup",
-      [badStation],
-      undefined,
-      HTTP_Unprocessable
-    );
+    cy.apiGroupStationsUpdate( "gsGroupAdmin", "gsGroup", [badStation], undefined, HTTP_Unprocessable);
 
     badStation = { name: "hello", lat: -45, lng: 172, randomParameter: true };
     //unexpected parameters ignored
     //cy.apiGroupStationsUpdate("gsGroupAdmin","gsGroup",[badStation],undefined,HTTP_Unprocessable);
-    cy.apiGroupStationsUpdate(
-      "gsGroupAdmin",
-      "gsGroup",
-      [badStation],
-      undefined,
-      HTTP_OK200
-    );
+    cy.apiGroupStationsUpdate( "gsGroupAdmin", "gsGroup", [badStation], undefined, HTTP_OK200);
 
     //but a valid one still works
-    cy.apiGroupStationsUpdate(
-      "gsGroupAdmin",
-      "gsGroup",
-      [station1a],
-      undefined,
-      HTTP_OK200
-    );
+    cy.apiGroupStationsUpdate( "gsGroupAdmin", "gsGroup", [station1a], undefined, HTTP_OK200);
+  });
+
+  it("Stations too close rejected", () => {
+   cy.apiGroupAdd("gsGroupAdmin", "gsGroupG");
+    cy.log("Add a station");
+    cy.apiGroupStationsUpdate("gsGroupAdmin", "gsGroupG", [ station1a ]);
+
+    cy.log("Attempt to add another too close");
+    let badStation = { name: "tooClose", lat: -45.100001, lng: 172.100001 };
+    cy.apiGroupStationsUpdate("gsGroupAdmin", "gsGroupG", [ station1a, badStation ],undefined,HTTP_OK200,{warnings: ["Stations too close together"]});
+
+    cy.log("Attempt to add two too close at same time");
+    let badStation1 = { name: "tooClose", lat: -45.500001, lng: 172.100001 };
+    let badStation2 = { name: "tooClose", lat: -45.500002, lng: 172.100001 };
+    cy.apiGroupStationsUpdate("gsGroupAdmin", "gsGroupG", [ station1a, badStation1, badStation2], undefined, HTTP_OK200, {warnings: ["Stations too close together"] });
+  });
+
+  it("Add new station with same name as retired station - both kept", () => {
+   cy.apiGroupAdd("gsGroupAdmin", "gsGroupF");
+  
+    cy.log("Add two stations");
+    cy.apiGroupStationsUpdate("gsGroupAdmin", "gsGroupF", [ station1a, station2a ]);
+  
+    cy.log("retire station");
+    cy.apiGroupStationsUpdate("gsGroupAdmin", "gsGroupF", [ station1a ]);
+
+    cy.log("Re-add new station");
+    cy.apiGroupStationsUpdate("gsGroupAdmin", "gsGroupF", [ station1a, station2b ]).then(() => {
+      expectedStation1a["GroupId"] = getCreds("gsGroupF").id;
+      expectedStation1a["retiredAt"] = null;
+      expectedStation1a["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
+      expectedStation2a["GroupId"] = getCreds("gsGroupF").id;
+      expectedStation2a["retiredAt"] = NOT_NULL;
+      expectedStation2a["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
+      expectedStation2b["GroupId"] = getCreds("gsGroupF").id;
+      expectedStation2b["retiredAt"] = null;
+      expectedStation2b["lastUpdatedById"] = getCreds("gsGroupAdmin").id;
+
+      //check both retired and new station shows 
+      cy.apiGroupsStationsCheck( "gsGroupAdmin", "gsGroupF", [expectedStation1a, expectedStation2a, expectedStation2b], EXCLUDE_CREATED_UPDATED_ID);
+      
+    });
   });
 
   it("From date validated correctly", () => {
     const timestamp = new Date().toISOString();
     cy.log("from date timestamp accepted");
-    cy.apiGroupStationsUpdate(
-      "gsGroupAdmin",
-      "gsGroup",
-      [station1a],
-      timestamp,
-      HTTP_OK200
-    );
+    cy.apiGroupStationsUpdate( "gsGroupAdmin", "gsGroup", [station1a], timestamp, HTTP_OK200);
 
     cy.log("from date absent accepted");
-    cy.apiGroupStationsUpdate(
-      "gsGroupAdmin",
-      "gsGroup",
-      [station1a],
-      undefined,
-      HTTP_OK200
-    );
+    cy.apiGroupStationsUpdate( "gsGroupAdmin", "gsGroup", [station1a], undefined, HTTP_OK200);
 
     cy.log("from date blank rejected");
-    cy.apiGroupStationsUpdate(
-      "gsGroupAdmin",
-      "gsGroup",
-      [station1a],
-      "",
-      HTTP_Unprocessable
-    );
+    cy.apiGroupStationsUpdate( "gsGroupAdmin", "gsGroup", [station1a], "", HTTP_Unprocessable);
 
     cy.log("malformed from date rejected");
-    cy.apiGroupStationsUpdate(
-      "gsGroupAdmin",
-      "gsGroup",
-      [station1a],
-      "ThisIsNotADate",
-      HTTP_Unprocessable
-    );
+    cy.apiGroupStationsUpdate( "gsGroupAdmin", "gsGroup", [station1a], "ThisIsNotADate", HTTP_Unprocessable);
   });
 
   //Mapping of recording to stations tested in the recordings section

--- a/integration-tests/cypress/integration/api/groups/groups_users_add_check_remove.ts
+++ b/integration-tests/cypress/integration/api/groups/groups_users_add_check_remove.ts
@@ -8,19 +8,32 @@ import { HTTP_OK200 } from "../../../commands/constants";
 import { HTTP_Unprocessable } from "../../../commands/constants";
 import { HTTP_Forbidden } from "../../../commands/constants";
 
-const ADMIN=true;
-const NOT_ADMIN=false;
-let expectedGuAdminUser:ApiGroupsUserReturned;
-let expectedGuAdminUser2:ApiGroupsUserReturned;
+const ADMIN = true;
+const NOT_ADMIN = false;
+let expectedGuAdminUser: ApiGroupsUserReturned;
+let expectedGuAdminUser2: ApiGroupsUserReturned;
 
 describe("Groups - add, check and remove users", () => {
-
   before(() => {
-    cy.testCreateUserGroupAndDevice("guGroupAdmin", "guGroup", "guCamera").then(() => {
-        expectedGuAdminUser={userName: getTestName("guGroupAdmin"), id: getCreds("guGroupAdmin").id, isGroupAdmin: ADMIN};
-    });
-    cy.testCreateUserGroupAndDevice("guGroup2Admin", "guGroup2", "guCamera2").then(() => {
-        expectedGuAdminUser2={userName: getTestName("guGroup2Admin"), id: getCreds("guGroup2Admin").id, isGroupAdmin: ADMIN};
+    cy.testCreateUserGroupAndDevice("guGroupAdmin", "guGroup", "guCamera").then(
+      () => {
+        expectedGuAdminUser = {
+          userName: getTestName("guGroupAdmin"),
+          id: getCreds("guGroupAdmin").id,
+          isGroupAdmin: ADMIN,
+        };
+      }
+    );
+    cy.testCreateUserGroupAndDevice(
+      "guGroup2Admin",
+      "guGroup2",
+      "guCamera2"
+    ).then(() => {
+      expectedGuAdminUser2 = {
+        userName: getTestName("guGroup2Admin"),
+        id: getCreds("guGroup2Admin").id,
+        isGroupAdmin: ADMIN,
+      };
     });
     cy.apiUserAdd("guDeviceAdmin");
     cy.apiDeviceUserAdd("guGroupAdmin", "guDeviceAdmin", "guCamera", ADMIN);
@@ -30,41 +43,69 @@ describe("Groups - add, check and remove users", () => {
   });
 
   it("Group admin can add, view and remove a new user", () => {
-    const expectedTestUser:ApiGroupsUserReturned={userName: getTestName("guTestUser"), id: getCreds("guTestUser").id, isGroupAdmin: ADMIN};
+    const expectedTestUser: ApiGroupsUserReturned = {
+      userName: getTestName("guTestUser"),
+      id: getCreds("guTestUser").id,
+      isGroupAdmin: ADMIN,
+    };
 
     cy.log("add the user");
     cy.apiGroupUserAdd("guGroupAdmin", "guTestUser", "guGroup", ADMIN);
 
     cy.log("check that added user is there");
-    cy.apiGroupUsersCheck("guGroupAdmin", "guGroup", [expectedGuAdminUser, expectedTestUser]);
+    cy.apiGroupUsersCheck("guGroupAdmin", "guGroup", [
+      expectedGuAdminUser,
+      expectedTestUser,
+    ]);
 
     cy.log("remove the user");
     cy.apiGroupUserRemove("guGroupAdmin", "guTestUser", "guGroup");
 
-
     cy.log("check that added user is no longer there");
     cy.apiGroupUsersCheck("guGroupAdmin", "guGroup", [expectedGuAdminUser]);
-
   });
 
   it("Group member cannot add, or remove a user but can view", () => {
-    const expectedTestUser:ApiGroupsUserReturned={userName: getTestName("guTestUser"), id: getCreds("guTestUser").id, isGroupAdmin: NOT_ADMIN};
+    const expectedTestUser: ApiGroupsUserReturned = {
+      userName: getTestName("guTestUser"),
+      id: getCreds("guTestUser").id,
+      isGroupAdmin: NOT_ADMIN,
+    };
 
     cy.log("add a non admin user (to run the test)");
     cy.apiGroupUserAdd("guGroupAdmin", "guTestUser", "guGroup", NOT_ADMIN);
 
     cy.log("check non-admin cannot add a user");
-    cy.apiGroupUserAdd("guTestUser", "guTestUser2", "guGroup", NOT_ADMIN, true, HTTP_Forbidden);
+    cy.apiGroupUserAdd(
+      "guTestUser",
+      "guTestUser2",
+      "guGroup",
+      NOT_ADMIN,
+      true,
+      HTTP_Forbidden
+    );
 
-    cy.log("check that new user was not created and group member can see users list");
-    cy.apiGroupUsersCheck("guTestUser", "guGroup", [expectedGuAdminUser, expectedTestUser]);
+    cy.log(
+      "check that new user was not created and group member can see users list"
+    );
+    cy.apiGroupUsersCheck("guTestUser", "guGroup", [
+      expectedGuAdminUser,
+      expectedTestUser,
+    ]);
 
     cy.log("attempt to remove a user using non admin account");
-    cy.apiGroupUserRemove("guTestUser", "guGroupAdmin", "guGroup", HTTP_Forbidden);
-
+    cy.apiGroupUserRemove(
+      "guTestUser",
+      "guGroupAdmin",
+      "guGroup",
+      HTTP_Forbidden
+    );
 
     cy.log("check that user was not deleted");
-    cy.apiGroupUsersCheck("guTestUser", "guGroup", [expectedGuAdminUser, expectedTestUser]);
+    cy.apiGroupUsersCheck("guTestUser", "guGroup", [
+      expectedGuAdminUser,
+      expectedTestUser,
+    ]);
 
     cy.log("tidy up after test - remove test user from group");
     cy.apiGroupUserRemove("guGroupAdmin", "guTestUser", "guGroup");
@@ -72,80 +113,169 @@ describe("Groups - add, check and remove users", () => {
 
   it("Group admin cannot add, view or remove users from another group", () => {
     cy.log("check admin cannot add a user to another group");
-    cy.apiGroupUserAdd("guGroupAdmin", "guTestUser2", "guGroup2", NOT_ADMIN, true, HTTP_Forbidden);
+    cy.apiGroupUserAdd(
+      "guGroupAdmin",
+      "guTestUser2",
+      "guGroup2",
+      NOT_ADMIN,
+      true,
+      HTTP_Forbidden
+    );
 
     cy.log("check that group admin cannot view another groups user list");
     cy.apiGroupUsersCheck("guGroupAdmin", "guGroup2", [], [], HTTP_Forbidden);
 
     cy.log("attempt to remove a user using non admin account");
-    cy.apiGroupUserRemove("guGroupAdmin", "guGroup2Admin", "guGroup2", HTTP_Forbidden);
+    cy.apiGroupUserRemove(
+      "guGroupAdmin",
+      "guGroup2Admin",
+      "guGroup2",
+      HTTP_Forbidden
+    );
   });
 
   it("Device admin cannot add, view or remove group users", () => {
     cy.log("check device admin cannot add a user to device's group");
-    cy.apiGroupUserAdd("guDeviceAdmin", "guTestUser", "guGroup", NOT_ADMIN, true, HTTP_Forbidden);
-      
+    cy.apiGroupUserAdd(
+      "guDeviceAdmin",
+      "guTestUser",
+      "guGroup",
+      NOT_ADMIN,
+      true,
+      HTTP_Forbidden
+    );
+
     cy.log("check that device admin cannot view device's groups user list");
     cy.apiGroupUsersCheck("guDeviceAdmin", "guGroup", [], [], HTTP_Forbidden);
-      
+
     cy.log("check that device admin cannot remove user from device's group");
-    cy.apiGroupUserRemove("guDeviceAdmin", "guGroupAdmin", "guGroup", HTTP_Forbidden);
+    cy.apiGroupUserRemove(
+      "guDeviceAdmin",
+      "guGroupAdmin",
+      "guGroup",
+      HTTP_Forbidden
+    );
   });
 
   it("Attempt to add or remove non-existant user fails nicely", () => {
     cy.log("check cannot add non-existanct user");
-    cy.apiGroupUserAdd("guGroupAdmin", "IDontExist", "guGroup", NOT_ADMIN, true, HTTP_Unprocessable);
+    cy.apiGroupUserAdd(
+      "guGroupAdmin",
+      "IDontExist",
+      "guGroup",
+      NOT_ADMIN,
+      true,
+      HTTP_Unprocessable
+    );
 
     //TODO: This test fails - returns SUCCESS. Issue 75
     //cy.log("check that connot remove non-existant user (user exists but not in group)");
     //cy.apiGroupUserRemove("guGroupAdmin", "guTestUser2", "guGroup", HTTP_Unprocessable);
 
-    cy.log("check that connot remove non-existant user (user not registered in system");
-    cy.apiGroupUserRemove("guGroupAdmin", "IDontExist", "guGroup", HTTP_Unprocessable);
+    cy.log(
+      "check that connot remove non-existant user (user not registered in system"
+    );
+    cy.apiGroupUserRemove(
+      "guGroupAdmin",
+      "IDontExist",
+      "guGroup",
+      HTTP_Unprocessable
+    );
   });
 
   it("Attempt to add view or remove user from non-existant group fails nicely", () => {
     cy.log("check cannot add user to non-existanct group");
-    cy.apiGroupUserAdd("guGroupAdmin", "guTestUser", "ThisGroupDoesNotExist", NOT_ADMIN, true, HTTP_Unprocessable);
+    cy.apiGroupUserAdd(
+      "guGroupAdmin",
+      "guTestUser",
+      "ThisGroupDoesNotExist",
+      NOT_ADMIN,
+      true,
+      HTTP_Unprocessable
+    );
 
     cy.log("check that cannot view a non existant group");
-    cy.apiGroupUsersCheck("guGroupAdmin", "ThisGroupDoesNotExist", [], [], HTTP_Unprocessable);
+    cy.apiGroupUsersCheck(
+      "guGroupAdmin",
+      "ThisGroupDoesNotExist",
+      [],
+      [],
+      HTTP_Unprocessable
+    );
 
-    cy.log("check that connot remove non-existant user (user not registered in system)");
-    cy.apiGroupUserRemove("guGroupAdmin", "guTestUser", "ThisGroupDoesNotExist", HTTP_Unprocessable);
+    cy.log(
+      "check that connot remove non-existant user (user not registered in system)"
+    );
+    cy.apiGroupUserRemove(
+      "guGroupAdmin",
+      "guTestUser",
+      "ThisGroupDoesNotExist",
+      HTTP_Unprocessable
+    );
   });
 
   it("Can view users using groupId (as well as groupName)", () => {
     cy.log("check that cannot view a non existant group");
-    cy.apiGroupUsersCheck("guGroupAdmin", getCreds("guGroup").id.toString(), [expectedGuAdminUser],[],HTTP_OK200,{useRawGroupName: true});
+    cy.apiGroupUsersCheck(
+      "guGroupAdmin",
+      getCreds("guGroup").id.toString(),
+      [expectedGuAdminUser],
+      [],
+      HTTP_OK200,
+      { useRawGroupName: true }
+    );
   });
 
   it("Can update admin/member status of existing user", () => {
-    const expectedTestNonAdminUser:ApiGroupsUserReturned={userName: getTestName("guTestUser"), id: getCreds("guTestUser").id, isGroupAdmin: NOT_ADMIN};
-    const expectedTestAdminUser:ApiGroupsUserReturned={userName: getTestName("guTestUser"), id: getCreds("guTestUser").id, isGroupAdmin: ADMIN};
-  
-      cy.log("add the user");
-      cy.apiGroupUserAdd("guGroupAdmin", "guTestUser", "guGroup", ADMIN);
-  
-      cy.log("check that added user is there");
-      cy.apiGroupUsersCheck("guGroupAdmin", "guGroup", [expectedGuAdminUser, expectedTestAdminUser]);
+    const expectedTestNonAdminUser: ApiGroupsUserReturned = {
+      userName: getTestName("guTestUser"),
+      id: getCreds("guTestUser").id,
+      isGroupAdmin: NOT_ADMIN,
+    };
+    const expectedTestAdminUser: ApiGroupsUserReturned = {
+      userName: getTestName("guTestUser"),
+      id: getCreds("guTestUser").id,
+      isGroupAdmin: ADMIN,
+    };
 
-      cy.log("change to non-admin")
-      cy.apiGroupUserAdd("guGroupAdmin", "guTestUser", "guGroup", NOT_ADMIN);
-  
-      cy.log("check that user is there only once, and shown as nonadmin");
-      cy.apiGroupUsersCheck("guGroupAdmin", "guGroup", [expectedGuAdminUser, expectedTestNonAdminUser]);
+    cy.log("add the user");
+    cy.apiGroupUserAdd("guGroupAdmin", "guTestUser", "guGroup", ADMIN);
 
-      cy.log("Verify user can no longer do admin tasks");
-      cy.apiGroupUserAdd("guTestUser", "guTestUser2", "guGroup", ADMIN, true, HTTP_Forbidden);
+    cy.log("check that added user is there");
+    cy.apiGroupUsersCheck("guGroupAdmin", "guGroup", [
+      expectedGuAdminUser,
+      expectedTestAdminUser,
+    ]);
 
-      cy.log("change to admin user");
-      cy.apiGroupUserAdd("guGroupAdmin", "guTestUser", "guGroup", ADMIN);
-  
-      cy.log("check that the user is there only once, and is an admin");
-      cy.apiGroupUsersCheck("guGroupAdmin", "guGroup", [expectedGuAdminUser, expectedTestAdminUser]);
+    cy.log("change to non-admin");
+    cy.apiGroupUserAdd("guGroupAdmin", "guTestUser", "guGroup", NOT_ADMIN);
 
-      cy.log("Verfiy that user can now do admin tasks (by removing themselves)");
-      cy.apiGroupUserRemove("guTestUser", "guTestUser", "guGroup");
+    cy.log("check that user is there only once, and shown as nonadmin");
+    cy.apiGroupUsersCheck("guGroupAdmin", "guGroup", [
+      expectedGuAdminUser,
+      expectedTestNonAdminUser,
+    ]);
+
+    cy.log("Verify user can no longer do admin tasks");
+    cy.apiGroupUserAdd(
+      "guTestUser",
+      "guTestUser2",
+      "guGroup",
+      ADMIN,
+      true,
+      HTTP_Forbidden
+    );
+
+    cy.log("change to admin user");
+    cy.apiGroupUserAdd("guGroupAdmin", "guTestUser", "guGroup", ADMIN);
+
+    cy.log("check that the user is there only once, and is an admin");
+    cy.apiGroupUsersCheck("guGroupAdmin", "guGroup", [
+      expectedGuAdminUser,
+      expectedTestAdminUser,
+    ]);
+
+    cy.log("Verfiy that user can now do admin tasks (by removing themselves)");
+    cy.apiGroupUserRemove("guTestUser", "guTestUser", "guGroup");
   });
 });

--- a/integration-tests/cypress/integration/api/groups/groups_users_add_check_remove.ts
+++ b/integration-tests/cypress/integration/api/groups/groups_users_add_check_remove.ts
@@ -16,17 +16,17 @@ let expectedGuAdminUser2:ApiGroupsUserReturned;
 describe("Groups - add, check and remove users", () => {
 
   before(() => {
-    cy.apiCreateUserGroupAndDevice("guGroupAdmin", "guGroup", "guCamera").then(() => {
+    cy.testCreateUserGroupAndDevice("guGroupAdmin", "guGroup", "guCamera").then(() => {
         expectedGuAdminUser={userName: getTestName("guGroupAdmin"), id: getCreds("guGroupAdmin").id, isGroupAdmin: ADMIN};
     });
-    cy.apiCreateUserGroupAndDevice("guGroup2Admin", "guGroup2", "guCamera2").then(() => {
+    cy.testCreateUserGroupAndDevice("guGroup2Admin", "guGroup2", "guCamera2").then(() => {
         expectedGuAdminUser2={userName: getTestName("guGroup2Admin"), id: getCreds("guGroup2Admin").id, isGroupAdmin: ADMIN};
     });
-    cy.apiCreateUser("guDeviceAdmin");
-    cy.apiAddUserToDevice("guGroupAdmin", "guDeviceAdmin", "guCamera", ADMIN);
+    cy.apiUserAdd("guDeviceAdmin");
+    cy.apiDeviceUserAdd("guGroupAdmin", "guDeviceAdmin", "guCamera", ADMIN);
 
-    cy.apiCreateUser("guTestUser");
-    cy.apiCreateUser("guTestUser2");
+    cy.apiUserAdd("guTestUser");
+    cy.apiUserAdd("guTestUser2");
   });
 
   it("Group admin can add, view and remove a new user", () => {

--- a/integration-tests/cypress/integration/api/groups/groups_users_add_check_remove.ts
+++ b/integration-tests/cypress/integration/api/groups/groups_users_add_check_remove.ts
@@ -1,0 +1,151 @@
+/// <reference path="../../../support/index.d.ts" />
+
+import { ApiGroupsUserReturned } from "../../../commands/types";
+import { getTestName } from "../../../commands/names";
+import { getCreds } from "../../../commands/server";
+
+import { HTTP_OK200 } from "../../../commands/constants";
+import { HTTP_Unprocessable } from "../../../commands/constants";
+import { HTTP_Forbidden } from "../../../commands/constants";
+
+const ADMIN=true;
+const NOT_ADMIN=false;
+let expectedGuAdminUser:ApiGroupsUserReturned;
+let expectedGuAdminUser2:ApiGroupsUserReturned;
+
+describe("Groups - add, check and remove users", () => {
+
+  before(() => {
+    cy.apiCreateUserGroupAndDevice("guGroupAdmin", "guGroup", "guCamera").then(() => {
+        expectedGuAdminUser={userName: getTestName("guGroupAdmin"), id: getCreds("guGroupAdmin").id, isGroupAdmin: ADMIN};
+    });
+    cy.apiCreateUserGroupAndDevice("guGroup2Admin", "guGroup2", "guCamera2").then(() => {
+        expectedGuAdminUser2={userName: getTestName("guGroup2Admin"), id: getCreds("guGroup2Admin").id, isGroupAdmin: ADMIN};
+    });
+    cy.apiCreateUser("guDeviceAdmin");
+    cy.apiAddUserToDevice("guGroupAdmin", "guDeviceAdmin", "guCamera", ADMIN);
+
+    cy.apiCreateUser("guTestUser");
+    cy.apiCreateUser("guTestUser2");
+  });
+
+  it("Group admin can add, view and remove a new user", () => {
+    const expectedTestUser:ApiGroupsUserReturned={userName: getTestName("guTestUser"), id: getCreds("guTestUser").id, isGroupAdmin: ADMIN};
+
+    cy.log("add the user");
+    cy.apiGroupUserAdd("guGroupAdmin", "guTestUser", "guGroup", ADMIN);
+
+    cy.log("check that added user is there");
+    cy.apiGroupUsersCheck("guGroupAdmin", "guGroup", [expectedGuAdminUser, expectedTestUser]);
+
+    cy.log("remove the user");
+    cy.apiGroupUserRemove("guGroupAdmin", "guTestUser", "guGroup");
+
+
+    cy.log("check that added user is no longer there");
+    cy.apiGroupUsersCheck("guGroupAdmin", "guGroup", [expectedGuAdminUser]);
+
+  });
+
+  it("Group member cannot add, or remove a user but can view", () => {
+    const expectedTestUser:ApiGroupsUserReturned={userName: getTestName("guTestUser"), id: getCreds("guTestUser").id, isGroupAdmin: NOT_ADMIN};
+
+    cy.log("add a non admin user (to run the test)");
+    cy.apiGroupUserAdd("guGroupAdmin", "guTestUser", "guGroup", NOT_ADMIN);
+
+    cy.log("check non-admin cannot add a user");
+    cy.apiGroupUserAdd("guTestUser", "guTestUser2", "guGroup", NOT_ADMIN, true, HTTP_Forbidden);
+
+    cy.log("check that new user was not created and group member can see users list");
+    cy.apiGroupUsersCheck("guTestUser", "guGroup", [expectedGuAdminUser, expectedTestUser]);
+
+    cy.log("attempt to remove a user using non admin account");
+    cy.apiGroupUserRemove("guTestUser", "guGroupAdmin", "guGroup", HTTP_Forbidden);
+
+
+    cy.log("check that user was not deleted");
+    cy.apiGroupUsersCheck("guTestUser", "guGroup", [expectedGuAdminUser, expectedTestUser]);
+
+    cy.log("tidy up after test - remove test user from group");
+    cy.apiGroupUserRemove("guGroupAdmin", "guTestUser", "guGroup");
+  });
+
+  it("Group admin cannot add, view or remove users from another group", () => {
+    cy.log("check admin cannot add a user to another group");
+    cy.apiGroupUserAdd("guGroupAdmin", "guTestUser2", "guGroup2", NOT_ADMIN, true, HTTP_Forbidden);
+
+    cy.log("check that group admin cannot view another groups user list");
+    cy.apiGroupUsersCheck("guGroupAdmin", "guGroup2", [], [], HTTP_Forbidden);
+
+    cy.log("attempt to remove a user using non admin account");
+    cy.apiGroupUserRemove("guGroupAdmin", "guGroup2Admin", "guGroup2", HTTP_Forbidden);
+  });
+
+  it("Device admin cannot add, view or remove group users", () => {
+    cy.log("check device admin cannot add a user to device's group");
+    cy.apiGroupUserAdd("guDeviceAdmin", "guTestUser", "guGroup", NOT_ADMIN, true, HTTP_Forbidden);
+      
+    cy.log("check that device admin cannot view device's groups user list");
+    cy.apiGroupUsersCheck("guDeviceAdmin", "guGroup", [], [], HTTP_Forbidden);
+      
+    cy.log("check that device admin cannot remove user from device's group");
+    cy.apiGroupUserRemove("guDeviceAdmin", "guGroupAdmin", "guGroup", HTTP_Forbidden);
+  });
+
+  it("Attempt to add or remove non-existant user fails nicely", () => {
+    cy.log("check cannot add non-existanct user");
+    cy.apiGroupUserAdd("guGroupAdmin", "IDontExist", "guGroup", NOT_ADMIN, true, HTTP_Unprocessable);
+
+    //TODO: This test fails - returns SUCCESS. Issue 75
+    //cy.log("check that connot remove non-existant user (user exists but not in group)");
+    //cy.apiGroupUserRemove("guGroupAdmin", "guTestUser2", "guGroup", HTTP_Unprocessable);
+
+    cy.log("check that connot remove non-existant user (user not registered in system");
+    cy.apiGroupUserRemove("guGroupAdmin", "IDontExist", "guGroup", HTTP_Unprocessable);
+  });
+
+  it("Attempt to add view or remove user from non-existant group fails nicely", () => {
+    cy.log("check cannot add user to non-existanct group");
+    cy.apiGroupUserAdd("guGroupAdmin", "guTestUser", "ThisGroupDoesNotExist", NOT_ADMIN, true, HTTP_Unprocessable);
+
+    cy.log("check that cannot view a non existant group");
+    cy.apiGroupUsersCheck("guGroupAdmin", "ThisGroupDoesNotExist", [], [], HTTP_Unprocessable);
+
+    cy.log("check that connot remove non-existant user (user not registered in system)");
+    cy.apiGroupUserRemove("guGroupAdmin", "guTestUser", "ThisGroupDoesNotExist", HTTP_Unprocessable);
+  });
+
+  it("Can view users using groupId (as well as groupName)", () => {
+    cy.log("check that cannot view a non existant group");
+    cy.apiGroupUsersCheck("guGroupAdmin", getCreds("guGroup").id.toString(), [expectedGuAdminUser],[],HTTP_OK200,{useRawGroupName: true});
+  });
+
+  it("Can update admin/member status of existing user", () => {
+    const expectedTestNonAdminUser:ApiGroupsUserReturned={userName: getTestName("guTestUser"), id: getCreds("guTestUser").id, isGroupAdmin: NOT_ADMIN};
+    const expectedTestAdminUser:ApiGroupsUserReturned={userName: getTestName("guTestUser"), id: getCreds("guTestUser").id, isGroupAdmin: ADMIN};
+  
+      cy.log("add the user");
+      cy.apiGroupUserAdd("guGroupAdmin", "guTestUser", "guGroup", ADMIN);
+  
+      cy.log("check that added user is there");
+      cy.apiGroupUsersCheck("guGroupAdmin", "guGroup", [expectedGuAdminUser, expectedTestAdminUser]);
+
+      cy.log("change to non-admin")
+      cy.apiGroupUserAdd("guGroupAdmin", "guTestUser", "guGroup", NOT_ADMIN);
+  
+      cy.log("check that user is there only once, and shown as nonadmin");
+      cy.apiGroupUsersCheck("guGroupAdmin", "guGroup", [expectedGuAdminUser, expectedTestNonAdminUser]);
+
+      cy.log("Verify user can no longer do admin tasks");
+      cy.apiGroupUserAdd("guTestUser", "guTestUser2", "guGroup", ADMIN, true, HTTP_Forbidden);
+
+      cy.log("change to admin user");
+      cy.apiGroupUserAdd("guGroupAdmin", "guTestUser", "guGroup", ADMIN);
+  
+      cy.log("check that the user is there only once, and is an admin");
+      cy.apiGroupUsersCheck("guGroupAdmin", "guGroup", [expectedGuAdminUser, expectedTestAdminUser]);
+
+      cy.log("Verfiy that user can now do admin tasks (by removing themselves)");
+      cy.apiGroupUserRemove("guTestUser", "guTestUser", "guGroup");
+  });
+});

--- a/integration-tests/cypress/integration/api/recordings/authorisation.ts
+++ b/integration-tests/cypress/integration/api/recordings/authorisation.ts
@@ -26,7 +26,7 @@ describe("Recording authorizations", () => {
 
   beforeEach(() => {
     if (!recordingUploaded) {
-      cy.testRecordingAddWithTestData(camera, { tags: ["possum"] });
+      cy.testUploadRecording(camera, { tags: ["possum"] });
       recordingUploaded = true;
     }
   });

--- a/integration-tests/cypress/integration/api/recordings/authorisation.ts
+++ b/integration-tests/cypress/integration/api/recordings/authorisation.ts
@@ -16,11 +16,11 @@ describe("Recording authorizations", () => {
   let recordingUploaded = false;
 
   before(() => {
-    cy.apiCreateUser(member);
-    cy.apiCreateUser(deviceMember);
-    cy.apiCreateUser(hacker);
-    cy.apiCreateUserGroupAndDevice(admin, group, camera);
-    cy.apiAddUserToDevice(admin, deviceMember, camera);
+    cy.apiUserAdd(member);
+    cy.apiUserAdd(deviceMember);
+    cy.apiUserAdd(hacker);
+    cy.testCreateUserGroupAndDevice(admin, group, camera);
+    cy.apiDeviceUserAdd(admin, deviceMember, camera);
     cy.apiGroupUserAdd(admin, member, group, NOT_ADMIN);
   });
 

--- a/integration-tests/cypress/integration/api/recordings/authorisation.ts
+++ b/integration-tests/cypress/integration/api/recordings/authorisation.ts
@@ -26,7 +26,7 @@ describe("Recording authorizations", () => {
 
   beforeEach(() => {
     if (!recordingUploaded) {
-      cy.uploadRecording(camera, { tags: ["possum"] });
+      cy.testRecordingAddWithTestData(camera, { tags: ["possum"] });
       recordingUploaded = true;
     }
   });

--- a/integration-tests/cypress/integration/api/recordings/authorisation.ts
+++ b/integration-tests/cypress/integration/api/recordings/authorisation.ts
@@ -21,7 +21,7 @@ describe("Recording authorizations", () => {
     cy.apiCreateUser(hacker);
     cy.apiCreateUserGroupAndDevice(admin, group, camera);
     cy.apiAddUserToDevice(admin, deviceMember, camera);
-    cy.apiAddUserToGroup(admin, member, group, NOT_ADMIN);
+    cy.apiGroupUserAdd(admin, member, group, NOT_ADMIN);
   });
 
   beforeEach(() => {

--- a/integration-tests/cypress/integration/api/recordings/monitoring_ai_model.ts
+++ b/integration-tests/cypress/integration/api/recordings/monitoring_ai_model.ts
@@ -11,22 +11,22 @@ describe("Monitoring : evaluate ai model", () => {
   it("By default, AI-tag returns what the AI Master model produces.  ", () => {
     const camera = "ai-default";
     cy.apiDeviceAdd(camera, group);
-    cy.testRecordingAddWithTestData(camera, {
+    cy.testUploadRecording(camera, {
       model: "Master",
       tags: ["possum"],
     });
-    cy.testRecordingAddWithTestData(camera, { model: "Catter", tags: ["cat"] });
+    cy.testUploadRecording(camera, { model: "Catter", tags: ["cat"] });
     cy.checkMonitoring(Claris, camera, [{ tag: "possum", aiTag: "possum" }]);
   });
 
   it("If an ai model is specified then it uses that model to calculate the results.  ", () => {
     const camera = "ai-different";
     cy.apiDeviceAdd(camera, group);
-    cy.testRecordingAddWithTestData(camera, {
+    cy.testUploadRecording(camera, {
       model: "Master",
       tags: ["possum"],
     });
-    cy.testRecordingAddWithTestData(camera, { model: "Catter", tags: ["cat"] });
+    cy.testUploadRecording(camera, { model: "Catter", tags: ["cat"] });
     cy.checkMonitoringWithFilter(Claris, camera, { ai: "Catter" }, [
       { tag: "possum", aiTag: "cat" },
     ]);
@@ -35,9 +35,9 @@ describe("Monitoring : evaluate ai model", () => {
   it("If an ai model is specified then it uses that model to calculate the results.  ", () => {
     const camera = "ai-users-best";
     cy.apiDeviceAdd(camera, group);
-    cy.testRecordingAddWithTestData(camera, { model: "Catter", tags: ["rat"] });
-    cy.testRecordingAddWithTestData(camera, { model: "Catter", tags: ["cat"] });
-    cy.testRecordingAddWithTestData(camera, { model: "Catter", tags: ["cat"] });
+    cy.testUploadRecording(camera, { model: "Catter", tags: ["rat"] });
+    cy.testUploadRecording(camera, { model: "Catter", tags: ["cat"] });
+    cy.testUploadRecording(camera, { model: "Catter", tags: ["cat"] });
     cy.checkMonitoringWithFilter(Claris, camera, { ai: "Catter" }, [
       { tag: "none", aiTag: "cat" },
     ]);

--- a/integration-tests/cypress/integration/api/recordings/monitoring_ai_model.ts
+++ b/integration-tests/cypress/integration/api/recordings/monitoring_ai_model.ts
@@ -11,16 +11,22 @@ describe("Monitoring : evaluate ai model", () => {
   it("By default, AI-tag returns what the AI Master model produces.  ", () => {
     const camera = "ai-default";
     cy.apiDeviceAdd(camera, group);
-    cy.uploadRecording(camera, { model: "Master", tags: ["possum"] });
-    cy.uploadRecording(camera, { model: "Catter", tags: ["cat"] });
+    cy.testRecordingAddWithTestData(camera, {
+      model: "Master",
+      tags: ["possum"],
+    });
+    cy.testRecordingAddWithTestData(camera, { model: "Catter", tags: ["cat"] });
     cy.checkMonitoring(Claris, camera, [{ tag: "possum", aiTag: "possum" }]);
   });
 
   it("If an ai model is specified then it uses that model to calculate the results.  ", () => {
     const camera = "ai-different";
     cy.apiDeviceAdd(camera, group);
-    cy.uploadRecording(camera, { model: "Master", tags: ["possum"] });
-    cy.uploadRecording(camera, { model: "Catter", tags: ["cat"] });
+    cy.testRecordingAddWithTestData(camera, {
+      model: "Master",
+      tags: ["possum"],
+    });
+    cy.testRecordingAddWithTestData(camera, { model: "Catter", tags: ["cat"] });
     cy.checkMonitoringWithFilter(Claris, camera, { ai: "Catter" }, [
       { tag: "possum", aiTag: "cat" },
     ]);
@@ -29,9 +35,9 @@ describe("Monitoring : evaluate ai model", () => {
   it("If an ai model is specified then it uses that model to calculate the results.  ", () => {
     const camera = "ai-users-best";
     cy.apiDeviceAdd(camera, group);
-    cy.uploadRecording(camera, { model: "Catter", tags: ["rat"] });
-    cy.uploadRecording(camera, { model: "Catter", tags: ["cat"] });
-    cy.uploadRecording(camera, { model: "Catter", tags: ["cat"] });
+    cy.testRecordingAddWithTestData(camera, { model: "Catter", tags: ["rat"] });
+    cy.testRecordingAddWithTestData(camera, { model: "Catter", tags: ["cat"] });
+    cy.testRecordingAddWithTestData(camera, { model: "Catter", tags: ["cat"] });
     cy.checkMonitoringWithFilter(Claris, camera, { ai: "Catter" }, [
       { tag: "none", aiTag: "cat" },
     ]);

--- a/integration-tests/cypress/integration/api/recordings/monitoring_ai_model.ts
+++ b/integration-tests/cypress/integration/api/recordings/monitoring_ai_model.ts
@@ -5,12 +5,12 @@ describe("Monitoring : evaluate ai model", () => {
   const group = "Visit-ai";
 
   before(() => {
-    cy.apiCreateUserGroup(Claris, group);
+    cy.testCreateUserAndGroup(Claris, group);
   });
 
   it("By default, AI-tag returns what the AI Master model produces.  ", () => {
     const camera = "ai-default";
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     cy.uploadRecording(camera, { model: "Master", tags: ["possum"] });
     cy.uploadRecording(camera, { model: "Catter", tags: ["cat"] });
     cy.checkMonitoring(Claris, camera, [{ tag: "possum", aiTag: "possum" }]);
@@ -18,7 +18,7 @@ describe("Monitoring : evaluate ai model", () => {
 
   it("If an ai model is specified then it uses that model to calculate the results.  ", () => {
     const camera = "ai-different";
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     cy.uploadRecording(camera, { model: "Master", tags: ["possum"] });
     cy.uploadRecording(camera, { model: "Catter", tags: ["cat"] });
     cy.checkMonitoringWithFilter(Claris, camera, { ai: "Catter" }, [
@@ -28,7 +28,7 @@ describe("Monitoring : evaluate ai model", () => {
 
   it("If an ai model is specified then it uses that model to calculate the results.  ", () => {
     const camera = "ai-users-best";
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     cy.uploadRecording(camera, { model: "Catter", tags: ["rat"] });
     cy.uploadRecording(camera, { model: "Catter", tags: ["cat"] });
     cy.uploadRecording(camera, { model: "Catter", tags: ["cat"] });

--- a/integration-tests/cypress/integration/api/recordings/monitoring_cameras.ts
+++ b/integration-tests/cypress/integration/api/recordings/monitoring_cameras.ts
@@ -2,14 +2,14 @@ describe("Monitoring : multiple cameras and stations", () => {
   const Penny = "Penny";
 
   before(() => {
-    cy.apiCreateUser(Penny);
+    cy.apiUserAdd(Penny);
   });
 
   it("Recordings at the same time on different cameras are never grouped together", () => {
     const group = "cameras-2";
     const cameraA = "cameraA";
     const cameraB = "cameraB";
-    cy.apiGroupAddAndDevices(Penny, group, cameraA, cameraB);
+    cy.testCreateGroupAndDevices(Penny, group, cameraA, cameraB);
     cy.uploadRecording(cameraA, { tags: ["possum"] });
     cy.uploadRecording(cameraB, { tags: ["cat"] });
     cy.checkMonitoring(Penny, null, [
@@ -21,13 +21,13 @@ describe("Monitoring : multiple cameras and stations", () => {
   it("Station name should be recorded, and reported", () => {
     const group = "stations";
     const camera = "camera";
-    cy.apiGroupAddAndDevices(Penny, group, camera);
+    cy.testCreateGroupAndDevices(Penny, group, camera);
 
     const stations = [
       { name: "forest", lat: -44.0, lng: 172.7 },
       { name: "waterfall", lat: -43.6, lng: 172.8 },
     ];
-    cy.apiGroupsStationsUpdate(Penny, group, stations);
+    cy.apiGroupStationsUpdate(Penny, group, stations);
     cy.uploadRecording(camera, { tags: ["possum"], lat: -44.0, lng: 172.7 });
     cy.uploadRecording(camera, { tags: ["cat"], lat: -44.0, lng: 172.7 });
     cy.checkMonitoring(Penny, camera, [{ station: "forest" }]);
@@ -36,13 +36,13 @@ describe("Monitoring : multiple cameras and stations", () => {
   it("If station changes the a new visit should be created", () => {
     const group = "stations-diff";
     const camera = "camera";
-    cy.apiGroupAddAndDevices(Penny, group, camera);
+    cy.testCreateGroupAndDevices(Penny, group, camera);
 
     const stations = [
       { name: "forest", lat: -44.0, lng: 172.7 },
       { name: "waterfall", lat: -43.6, lng: 172.8 },
     ];
-    cy.apiGroupsStationsUpdate(Penny, group, stations);
+    cy.apiGroupStationsUpdate(Penny, group, stations);
     cy.uploadRecording(camera, { tags: ["possum"], lat: -44.0, lng: 172.7 });
     cy.uploadRecording(camera, { tags: ["cat"], lat: -43.6, lng: 172.8 });
     cy.checkMonitoring(Penny, camera, [

--- a/integration-tests/cypress/integration/api/recordings/monitoring_cameras.ts
+++ b/integration-tests/cypress/integration/api/recordings/monitoring_cameras.ts
@@ -10,8 +10,8 @@ describe("Monitoring : multiple cameras and stations", () => {
     const cameraA = "cameraA";
     const cameraB = "cameraB";
     cy.testCreateGroupAndDevices(Penny, group, cameraA, cameraB);
-    cy.uploadRecording(cameraA, { tags: ["possum"] });
-    cy.uploadRecording(cameraB, { tags: ["cat"] });
+    cy.testRecordingAddWithTestData(cameraA, { tags: ["possum"] });
+    cy.testRecordingAddWithTestData(cameraB, { tags: ["cat"] });
     cy.checkMonitoring(Penny, null, [
       { camera: cameraA, tag: "possum" },
       { camera: cameraB, tag: "cat" },
@@ -28,8 +28,16 @@ describe("Monitoring : multiple cameras and stations", () => {
       { name: "waterfall", lat: -43.6, lng: 172.8 },
     ];
     cy.apiGroupStationsUpdate(Penny, group, stations);
-    cy.uploadRecording(camera, { tags: ["possum"], lat: -44.0, lng: 172.7 });
-    cy.uploadRecording(camera, { tags: ["cat"], lat: -44.0, lng: 172.7 });
+    cy.testRecordingAddWithTestData(camera, {
+      tags: ["possum"],
+      lat: -44.0,
+      lng: 172.7,
+    });
+    cy.testRecordingAddWithTestData(camera, {
+      tags: ["cat"],
+      lat: -44.0,
+      lng: 172.7,
+    });
     cy.checkMonitoring(Penny, camera, [{ station: "forest" }]);
   });
 
@@ -43,8 +51,16 @@ describe("Monitoring : multiple cameras and stations", () => {
       { name: "waterfall", lat: -43.6, lng: 172.8 },
     ];
     cy.apiGroupStationsUpdate(Penny, group, stations);
-    cy.uploadRecording(camera, { tags: ["possum"], lat: -44.0, lng: 172.7 });
-    cy.uploadRecording(camera, { tags: ["cat"], lat: -43.6, lng: 172.8 });
+    cy.testRecordingAddWithTestData(camera, {
+      tags: ["possum"],
+      lat: -44.0,
+      lng: 172.7,
+    });
+    cy.testRecordingAddWithTestData(camera, {
+      tags: ["cat"],
+      lat: -43.6,
+      lng: 172.8,
+    });
     cy.checkMonitoring(Penny, camera, [
       { station: "forest" },
       { station: "waterfall" },

--- a/integration-tests/cypress/integration/api/recordings/monitoring_cameras.ts
+++ b/integration-tests/cypress/integration/api/recordings/monitoring_cameras.ts
@@ -10,8 +10,8 @@ describe("Monitoring : multiple cameras and stations", () => {
     const cameraA = "cameraA";
     const cameraB = "cameraB";
     cy.testCreateGroupAndDevices(Penny, group, cameraA, cameraB);
-    cy.testRecordingAddWithTestData(cameraA, { tags: ["possum"] });
-    cy.testRecordingAddWithTestData(cameraB, { tags: ["cat"] });
+    cy.testUploadRecording(cameraA, { tags: ["possum"] });
+    cy.testUploadRecording(cameraB, { tags: ["cat"] });
     cy.checkMonitoring(Penny, null, [
       { camera: cameraA, tag: "possum" },
       { camera: cameraB, tag: "cat" },
@@ -28,12 +28,12 @@ describe("Monitoring : multiple cameras and stations", () => {
       { name: "waterfall", lat: -43.6, lng: 172.8 },
     ];
     cy.apiGroupStationsUpdate(Penny, group, stations);
-    cy.testRecordingAddWithTestData(camera, {
+    cy.testUploadRecording(camera, {
       tags: ["possum"],
       lat: -44.0,
       lng: 172.7,
     });
-    cy.testRecordingAddWithTestData(camera, {
+    cy.testUploadRecording(camera, {
       tags: ["cat"],
       lat: -44.0,
       lng: 172.7,
@@ -51,12 +51,12 @@ describe("Monitoring : multiple cameras and stations", () => {
       { name: "waterfall", lat: -43.6, lng: 172.8 },
     ];
     cy.apiGroupStationsUpdate(Penny, group, stations);
-    cy.testRecordingAddWithTestData(camera, {
+    cy.testUploadRecording(camera, {
       tags: ["possum"],
       lat: -44.0,
       lng: 172.7,
     });
-    cy.testRecordingAddWithTestData(camera, {
+    cy.testUploadRecording(camera, {
       tags: ["cat"],
       lat: -43.6,
       lng: 172.8,

--- a/integration-tests/cypress/integration/api/recordings/monitoring_cameras.ts
+++ b/integration-tests/cypress/integration/api/recordings/monitoring_cameras.ts
@@ -9,7 +9,7 @@ describe("Monitoring : multiple cameras and stations", () => {
     const group = "cameras-2";
     const cameraA = "cameraA";
     const cameraB = "cameraB";
-    cy.apiCreateGroupAndDevices(Penny, group, cameraA, cameraB);
+    cy.apiGroupAddAndDevices(Penny, group, cameraA, cameraB);
     cy.uploadRecording(cameraA, { tags: ["possum"] });
     cy.uploadRecording(cameraB, { tags: ["cat"] });
     cy.checkMonitoring(Penny, null, [
@@ -21,13 +21,13 @@ describe("Monitoring : multiple cameras and stations", () => {
   it("Station name should be recorded, and reported", () => {
     const group = "stations";
     const camera = "camera";
-    cy.apiCreateGroupAndDevices(Penny, group, camera);
+    cy.apiGroupAddAndDevices(Penny, group, camera);
 
     const stations = [
       { name: "forest", lat: -44.0, lng: 172.7 },
       { name: "waterfall", lat: -43.6, lng: 172.8 },
     ];
-    cy.apiUploadStations(Penny, group, stations);
+    cy.apiGroupsStationsUpdate(Penny, group, stations);
     cy.uploadRecording(camera, { tags: ["possum"], lat: -44.0, lng: 172.7 });
     cy.uploadRecording(camera, { tags: ["cat"], lat: -44.0, lng: 172.7 });
     cy.checkMonitoring(Penny, camera, [{ station: "forest" }]);
@@ -36,13 +36,13 @@ describe("Monitoring : multiple cameras and stations", () => {
   it("If station changes the a new visit should be created", () => {
     const group = "stations-diff";
     const camera = "camera";
-    cy.apiCreateGroupAndDevices(Penny, group, camera);
+    cy.apiGroupAddAndDevices(Penny, group, camera);
 
     const stations = [
       { name: "forest", lat: -44.0, lng: 172.7 },
       { name: "waterfall", lat: -43.6, lng: 172.8 },
     ];
-    cy.apiUploadStations(Penny, group, stations);
+    cy.apiGroupsStationsUpdate(Penny, group, stations);
     cy.uploadRecording(camera, { tags: ["possum"], lat: -44.0, lng: 172.7 });
     cy.uploadRecording(camera, { tags: ["cat"], lat: -43.6, lng: 172.8 });
     cy.checkMonitoring(Penny, camera, [

--- a/integration-tests/cypress/integration/api/recordings/monitoring_filters.ts
+++ b/integration-tests/cypress/integration/api/recordings/monitoring_filters.ts
@@ -16,9 +16,9 @@ describe("Monitoring : filters", () => {
   const date4 = new Date(2021, 2, 6, 10);
 
   before(() => {
-    cy.apiCreateUser(Poppy);
-    cy.apiGroupAddAndDevices(Poppy, groupRabbits, cameraRabbits);
-    cy.apiGroupAddAndDevices(Poppy, groupHedgehogs, cameraHedgehogs);
+    cy.apiUserAdd(Poppy);
+    cy.testCreateGroupAndDevices(Poppy, groupRabbits, cameraRabbits);
+    cy.testCreateGroupAndDevices(Poppy, groupHedgehogs, cameraHedgehogs);
   });
 
   beforeEach(() => {

--- a/integration-tests/cypress/integration/api/recordings/monitoring_filters.ts
+++ b/integration-tests/cypress/integration/api/recordings/monitoring_filters.ts
@@ -23,10 +23,22 @@ describe("Monitoring : filters", () => {
 
   beforeEach(() => {
     if (!recordingsUploaded) {
-      cy.uploadRecording(cameraRabbits, { time: date1, tags: ["rabbit"] });
-      cy.uploadRecording(cameraHedgehogs, { time: date2, tags: ["hedgehog"] });
-      cy.uploadRecording(cameraHedgehogs, { time: date3, tags: ["hedgehog"] });
-      cy.uploadRecording(cameraRabbits, { time: date4, tags: ["rabbit"] });
+      cy.testRecordingAddWithTestData(cameraRabbits, {
+        time: date1,
+        tags: ["rabbit"],
+      });
+      cy.testRecordingAddWithTestData(cameraHedgehogs, {
+        time: date2,
+        tags: ["hedgehog"],
+      });
+      cy.testRecordingAddWithTestData(cameraHedgehogs, {
+        time: date3,
+        tags: ["hedgehog"],
+      });
+      cy.testRecordingAddWithTestData(cameraRabbits, {
+        time: date4,
+        tags: ["rabbit"],
+      });
     }
   });
 

--- a/integration-tests/cypress/integration/api/recordings/monitoring_filters.ts
+++ b/integration-tests/cypress/integration/api/recordings/monitoring_filters.ts
@@ -17,8 +17,8 @@ describe("Monitoring : filters", () => {
 
   before(() => {
     cy.apiCreateUser(Poppy);
-    cy.apiCreateGroupAndDevices(Poppy, groupRabbits, cameraRabbits);
-    cy.apiCreateGroupAndDevices(Poppy, groupHedgehogs, cameraHedgehogs);
+    cy.apiGroupAddAndDevices(Poppy, groupRabbits, cameraRabbits);
+    cy.apiGroupAddAndDevices(Poppy, groupHedgehogs, cameraHedgehogs);
   });
 
   beforeEach(() => {

--- a/integration-tests/cypress/integration/api/recordings/monitoring_filters.ts
+++ b/integration-tests/cypress/integration/api/recordings/monitoring_filters.ts
@@ -23,19 +23,19 @@ describe("Monitoring : filters", () => {
 
   beforeEach(() => {
     if (!recordingsUploaded) {
-      cy.testRecordingAddWithTestData(cameraRabbits, {
+      cy.testUploadRecording(cameraRabbits, {
         time: date1,
         tags: ["rabbit"],
       });
-      cy.testRecordingAddWithTestData(cameraHedgehogs, {
+      cy.testUploadRecording(cameraHedgehogs, {
         time: date2,
         tags: ["hedgehog"],
       });
-      cy.testRecordingAddWithTestData(cameraHedgehogs, {
+      cy.testUploadRecording(cameraHedgehogs, {
         time: date3,
         tags: ["hedgehog"],
       });
-      cy.testRecordingAddWithTestData(cameraRabbits, {
+      cy.testUploadRecording(cameraRabbits, {
         time: date4,
         tags: ["rabbit"],
       });

--- a/integration-tests/cypress/integration/api/recordings/monitoring_paging.ts
+++ b/integration-tests/cypress/integration/api/recordings/monitoring_paging.ts
@@ -13,7 +13,7 @@ describe("Monitoring : pagings", () => {
     const camera = "basic";
 
     cy.apiDeviceAdd(camera, group);
-    cy.uploadRecordingsAtTimes(camera, [
+    cy.testAddRecordingsAtTimes(camera, [
       "21:03",
       "21:23",
       "21:43",
@@ -51,8 +51,8 @@ describe("Monitoring : pagings", () => {
     const camera2 = "cam-2";
     cy.apiDeviceAdd(camera1, group);
     cy.apiDeviceAdd(camera2, group);
-    cy.uploadRecordingsAtTimes(camera1, ["21:03", "21:14", "21:25"]);
-    cy.uploadRecordingsAtTimes(camera2, ["21:13", "21:18", "21:27"]); // all one visit
+    cy.testAddRecordingsAtTimes(camera1, ["21:03", "21:14", "21:25"]);
+    cy.testAddRecordingsAtTimes(camera2, ["21:13", "21:18", "21:27"]); // all one visit
 
     cy.checkMonitoringWithFilter(Henry, null, { "page-size": 3, page: 1 }, [
       { recordings: 3, start: "21:13" },
@@ -75,10 +75,10 @@ describe("Monitoring : pagings", () => {
     cy.apiUserAdd(Bobletta);
     cy.testCreateGroupAndDevices(Bobletta, group, camera1, camera2, camera3);
 
-    cy.uploadRecording(camera1, { time: visitTime });
-    cy.uploadRecording(camera2, { time: visitTime });
-    cy.uploadRecording(camera3, { time: visitTime });
-    cy.uploadRecording(camera1, { time: nextVisitTime });
+    cy.testRecordingAddWithTestData(camera1, { time: visitTime });
+    cy.testRecordingAddWithTestData(camera2, { time: visitTime });
+    cy.testRecordingAddWithTestData(camera3, { time: visitTime });
+    cy.testRecordingAddWithTestData(camera1, { time: nextVisitTime });
 
     cy.checkMonitoringWithFilter(Bobletta, null, { "page-size": 2, page: 2 }, [
       { start: visitTime },
@@ -93,7 +93,7 @@ describe("Monitoring : pagings", () => {
   it("visits that start before search period but cross into search period are only shown on the last page", () => {
     const camera = "close recordings";
     cy.apiDeviceAdd(camera, group);
-    cy.uploadRecordingsAtTimes(camera, [
+    cy.testAddRecordingsAtTimes(camera, [
       "21:03",
       "21:13",
       "21:40",

--- a/integration-tests/cypress/integration/api/recordings/monitoring_paging.ts
+++ b/integration-tests/cypress/integration/api/recordings/monitoring_paging.ts
@@ -73,7 +73,7 @@ describe("Monitoring : pagings", () => {
     const visitTime = "21:10";
     const nextVisitTime = "21:33";
     cy.apiCreateUser(Bobletta);
-    cy.apiCreateGroupAndDevices(Bobletta, group, camera1, camera2, camera3);
+    cy.apiGroupAddAndDevices(Bobletta, group, camera1, camera2, camera3);
 
     cy.uploadRecording(camera1, { time: visitTime });
     cy.uploadRecording(camera2, { time: visitTime });

--- a/integration-tests/cypress/integration/api/recordings/monitoring_paging.ts
+++ b/integration-tests/cypress/integration/api/recordings/monitoring_paging.ts
@@ -75,10 +75,10 @@ describe("Monitoring : pagings", () => {
     cy.apiUserAdd(Bobletta);
     cy.testCreateGroupAndDevices(Bobletta, group, camera1, camera2, camera3);
 
-    cy.testRecordingAddWithTestData(camera1, { time: visitTime });
-    cy.testRecordingAddWithTestData(camera2, { time: visitTime });
-    cy.testRecordingAddWithTestData(camera3, { time: visitTime });
-    cy.testRecordingAddWithTestData(camera1, { time: nextVisitTime });
+    cy.testUploadRecording(camera1, { time: visitTime });
+    cy.testUploadRecording(camera2, { time: visitTime });
+    cy.testUploadRecording(camera3, { time: visitTime });
+    cy.testUploadRecording(camera1, { time: nextVisitTime });
 
     cy.checkMonitoringWithFilter(Bobletta, null, { "page-size": 2, page: 2 }, [
       { start: visitTime },

--- a/integration-tests/cypress/integration/api/recordings/monitoring_paging.ts
+++ b/integration-tests/cypress/integration/api/recordings/monitoring_paging.ts
@@ -6,13 +6,13 @@ describe("Monitoring : pagings", () => {
   const group = "visits-paging";
 
   before(() => {
-    cy.apiCreateUserGroup(Veronica, group);
+    cy.testCreateUserAndGroup(Veronica, group);
   });
 
   it("recordings are broken into approximate pages by start date", () => {
     const camera = "basic";
 
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     cy.uploadRecordingsAtTimes(camera, [
       "21:03",
       "21:23",
@@ -46,11 +46,11 @@ describe("Monitoring : pagings", () => {
   it("visits can finish for some cameras beyond the start time for others", () => {
     const Henry = "Henry";
     const group = "visits-two-cams";
-    cy.apiCreateUserGroup(Henry, group);
+    cy.testCreateUserAndGroup(Henry, group);
     const camera1 = "cam-1";
     const camera2 = "cam-2";
-    cy.apiCreateDevice(camera1, group);
-    cy.apiCreateDevice(camera2, group);
+    cy.apiDeviceAdd(camera1, group);
+    cy.apiDeviceAdd(camera2, group);
     cy.uploadRecordingsAtTimes(camera1, ["21:03", "21:14", "21:25"]);
     cy.uploadRecordingsAtTimes(camera2, ["21:13", "21:18", "21:27"]); // all one visit
 
@@ -72,8 +72,8 @@ describe("Monitoring : pagings", () => {
     const camera3 = "cam-3";
     const visitTime = "21:10";
     const nextVisitTime = "21:33";
-    cy.apiCreateUser(Bobletta);
-    cy.apiGroupAddAndDevices(Bobletta, group, camera1, camera2, camera3);
+    cy.apiUserAdd(Bobletta);
+    cy.testCreateGroupAndDevices(Bobletta, group, camera1, camera2, camera3);
 
     cy.uploadRecording(camera1, { time: visitTime });
     cy.uploadRecording(camera2, { time: visitTime });
@@ -92,7 +92,7 @@ describe("Monitoring : pagings", () => {
 
   it("visits that start before search period but cross into search period are only shown on the last page", () => {
     const camera = "close recordings";
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     cy.uploadRecordingsAtTimes(camera, [
       "21:03",
       "21:13",

--- a/integration-tests/cypress/integration/api/recordings/monitoring_tags.ts
+++ b/integration-tests/cypress/integration/api/recordings/monitoring_tags.ts
@@ -17,39 +17,44 @@ describe("Monitoring : tracks and tags", () => {
     const notracks = [];
     const noVisits = [];
     cy.apiDeviceAdd(camera, group);
-    cy.uploadRecording(camera, { tracks: notracks });
+    cy.testRecordingAddWithTestData(camera, { tracks: notracks });
     cy.checkMonitoring(Damian, camera, noVisits);
   });
 
   it("all automatic tags other than master are ignored - to prevent wallaby ai being used on other projects", () => {
     const camera = "only_master";
     cy.apiDeviceAdd(camera, group);
-    cy.uploadRecording(camera, { model: "different", tags: ["cat"] });
+    cy.testRecordingAddWithTestData(camera, {
+      model: "different",
+      tags: ["cat"],
+    });
     cy.checkMonitoringTags(Damian, camera, ["none"]);
   });
 
   it("each recording contributes votes for what the animal is", () => {
     const camera = "multiple_tracks";
     cy.apiDeviceAdd(camera, group);
-    cy.uploadRecording(camera, { tags: ["possum", "rat"] });
-    cy.uploadRecording(camera, { tags: ["cat"] });
-    cy.uploadRecording(camera, { tags: ["cat"] });
+    cy.testRecordingAddWithTestData(camera, { tags: ["possum", "rat"] });
+    cy.testRecordingAddWithTestData(camera, { tags: ["cat"] });
+    cy.testRecordingAddWithTestData(camera, { tags: ["cat"] });
     cy.checkMonitoringTags(Damian, camera, ["cat"]);
   });
 
   it("each track in a recording gets contributes a vote for what the animal is", () => {
     const camera = "multiple_tracks2";
     cy.apiDeviceAdd(camera, group);
-    cy.uploadRecording(camera, { tags: ["possum", "rat", "rat", "rat"] });
-    cy.uploadRecording(camera, { tags: ["cat"] });
-    cy.uploadRecording(camera, { tags: ["cat"] });
+    cy.testRecordingAddWithTestData(camera, {
+      tags: ["possum", "rat", "rat", "rat"],
+    });
+    cy.testRecordingAddWithTestData(camera, { tags: ["cat"] });
+    cy.testRecordingAddWithTestData(camera, { tags: ["cat"] });
     cy.checkMonitoringTags(Damian, camera, ["rat"]);
   });
 
   it("track tag 'unidentified` is ignored when deciding label to use", () => {
     const camera = "has_unidentified";
     cy.apiDeviceAdd(camera, group);
-    cy.uploadRecording(camera, {
+    cy.testRecordingAddWithTestData(camera, {
       tags: ["possum", "unidentified", "unidentified", "unidentified"],
     });
     cy.checkMonitoringTags(Damian, camera, ["possum"]);
@@ -58,7 +63,7 @@ describe("Monitoring : tracks and tags", () => {
   it("What happens when user tags as 'unidentified`?", () => {
     const camera = "user_unidentified_tracks";
     cy.apiDeviceAdd(camera, group);
-    cy.uploadRecording(camera, { tags: ["possum"] }).thenUserTagAs(
+    cy.testRecordingAddWithTestData(camera, { tags: ["possum"] }).thenUserTagAs(
       Damian,
       "unidentified"
     );
@@ -68,42 +73,41 @@ describe("Monitoring : tracks and tags", () => {
   it("if a user tags a track then this is what should be used as the track tag", () => {
     const camera = "userTagged";
     cy.apiDeviceAdd(camera, group);
-    cy.uploadRecording(camera, { tracks: [{ tag: "cat" }] }).thenUserTagAs(
-      Damian,
-      "rabbit"
-    );
+    cy.testRecordingAddWithTestData(camera, {
+      tracks: [{ tag: "cat" }],
+    }).thenUserTagAs(Damian, "rabbit");
     cy.checkMonitoringTags(Damian, camera, ["rabbit"]);
   });
 
   it("User tag is preferred over AI tag", () => {
     const camera = "userVsMultiple";
     cy.apiDeviceAdd(camera, group);
-    cy.uploadRecording(camera, {
+    cy.testRecordingAddWithTestData(camera, {
       tags: ["possum", "rat", "rat"],
     }).thenUserTagAs(Damian, "rabbit");
-    cy.uploadRecording(camera, { tags: ["possum"] });
+    cy.testRecordingAddWithTestData(camera, { tags: ["possum"] });
     cy.checkMonitoringTags(Damian, camera, ["rabbit"]);
   });
 
   it("When user tag and AI tag aggree", () => {
     const camera = "tagsagree";
     cy.apiDeviceAdd(camera, group);
-    cy.uploadRecording(camera, {
+    cy.testRecordingAddWithTestData(camera, {
       tags: ["possum", "rat", "rat"],
     }).thenUserTagAs(Damian, "possum");
-    cy.uploadRecording(camera, { tags: ["possum"] });
+    cy.testRecordingAddWithTestData(camera, { tags: ["possum"] });
     cy.checkMonitoringTags(Damian, camera, ["possum"]);
   });
 
   it("User animal tag is preferred over user unknown tag", () => {
     const camera = "userAnimalUnknown";
     cy.apiDeviceAdd(camera, group);
-    cy.uploadRecording(camera, {
+    cy.testRecordingAddWithTestData(camera, {
       tags: ["unidentified", "unidentified", "unidentified"],
     }).then((recID: number) => {
-      cy.userTagRecording(recID, 0, Damian, "possum");
-      cy.userTagRecording(recID, 1, Damian, "unknown");
-      cy.userTagRecording(recID, 2, Damian, "unknown");
+      cy.testUserTagRecording(recID, 0, Damian, "possum");
+      cy.testUserTagRecording(recID, 1, Damian, "unknown");
+      cy.testUserTagRecording(recID, 2, Damian, "unknown");
     });
     cy.checkMonitoringTags(Damian, camera, ["possum"]);
   });
@@ -112,30 +116,29 @@ describe("Monitoring : tracks and tags", () => {
     cy.apiUserAdd(Gerry);
     cy.apiGroupUserAdd(Damian, Gerry, group, true);
     cy.apiDeviceAdd(camera, group);
-    const recording = cy.uploadRecording(camera, {
+    const recording = cy.testRecordingAddWithTestData(camera, {
       tags: ["possum", "rabbit"],
     });
     recording.then((recID: number) => {
-      cy.userTagRecording(recID, 0, Damian, "possum");
-      cy.userTagRecording(recID, 0, Gerry, "rat");
+      cy.testUserTagRecording(recID, 0, Damian, "possum");
+      cy.testUserTagRecording(recID, 0, Gerry, "rat");
     });
     cy.checkMonitoringTags(Damian, camera, ["conflicting tags"]);
   });
   it("User tags conflict on one of many tracks majority wins", () => {
     const camera = "conflicter-multiple";
     cy.apiDeviceAdd(camera, group);
-    const recording = cy.uploadRecording(camera, {
+    const recording = cy.testRecordingAddWithTestData(camera, {
       tags: ["possum", "rabbit"],
     });
     recording.then((recID: number) => {
-      cy.userTagRecording(recID, 0, Damian, "possum");
-      cy.userTagRecording(recID, 0, Gerry, "rat");
+      cy.testUserTagRecording(recID, 0, Damian, "possum");
+      cy.testUserTagRecording(recID, 0, Gerry, "rat");
     });
-    cy.uploadRecording(camera, { tags: ["possum", "rat"] }).thenUserTagAs(
-      Damian,
-      "possum"
-    );
-    cy.uploadRecording(camera, { tags: ["cat"] }).thenUserTagAs(
+    cy.testRecordingAddWithTestData(camera, {
+      tags: ["possum", "rat"],
+    }).thenUserTagAs(Damian, "possum");
+    cy.testRecordingAddWithTestData(camera, { tags: ["cat"] }).thenUserTagAs(
       Damian,
       "possum"
     );

--- a/integration-tests/cypress/integration/api/recordings/monitoring_tags.ts
+++ b/integration-tests/cypress/integration/api/recordings/monitoring_tags.ts
@@ -17,14 +17,14 @@ describe("Monitoring : tracks and tags", () => {
     const notracks = [];
     const noVisits = [];
     cy.apiDeviceAdd(camera, group);
-    cy.testRecordingAddWithTestData(camera, { tracks: notracks });
+    cy.testUploadRecording(camera, { tracks: notracks });
     cy.checkMonitoring(Damian, camera, noVisits);
   });
 
   it("all automatic tags other than master are ignored - to prevent wallaby ai being used on other projects", () => {
     const camera = "only_master";
     cy.apiDeviceAdd(camera, group);
-    cy.testRecordingAddWithTestData(camera, {
+    cy.testUploadRecording(camera, {
       model: "different",
       tags: ["cat"],
     });
@@ -34,27 +34,27 @@ describe("Monitoring : tracks and tags", () => {
   it("each recording contributes votes for what the animal is", () => {
     const camera = "multiple_tracks";
     cy.apiDeviceAdd(camera, group);
-    cy.testRecordingAddWithTestData(camera, { tags: ["possum", "rat"] });
-    cy.testRecordingAddWithTestData(camera, { tags: ["cat"] });
-    cy.testRecordingAddWithTestData(camera, { tags: ["cat"] });
+    cy.testUploadRecording(camera, { tags: ["possum", "rat"] });
+    cy.testUploadRecording(camera, { tags: ["cat"] });
+    cy.testUploadRecording(camera, { tags: ["cat"] });
     cy.checkMonitoringTags(Damian, camera, ["cat"]);
   });
 
   it("each track in a recording gets contributes a vote for what the animal is", () => {
     const camera = "multiple_tracks2";
     cy.apiDeviceAdd(camera, group);
-    cy.testRecordingAddWithTestData(camera, {
+    cy.testUploadRecording(camera, {
       tags: ["possum", "rat", "rat", "rat"],
     });
-    cy.testRecordingAddWithTestData(camera, { tags: ["cat"] });
-    cy.testRecordingAddWithTestData(camera, { tags: ["cat"] });
+    cy.testUploadRecording(camera, { tags: ["cat"] });
+    cy.testUploadRecording(camera, { tags: ["cat"] });
     cy.checkMonitoringTags(Damian, camera, ["rat"]);
   });
 
   it("track tag 'unidentified` is ignored when deciding label to use", () => {
     const camera = "has_unidentified";
     cy.apiDeviceAdd(camera, group);
-    cy.testRecordingAddWithTestData(camera, {
+    cy.testUploadRecording(camera, {
       tags: ["possum", "unidentified", "unidentified", "unidentified"],
     });
     cy.checkMonitoringTags(Damian, camera, ["possum"]);
@@ -63,7 +63,7 @@ describe("Monitoring : tracks and tags", () => {
   it("What happens when user tags as 'unidentified`?", () => {
     const camera = "user_unidentified_tracks";
     cy.apiDeviceAdd(camera, group);
-    cy.testRecordingAddWithTestData(camera, { tags: ["possum"] }).thenUserTagAs(
+    cy.testUploadRecording(camera, { tags: ["possum"] }).thenUserTagAs(
       Damian,
       "unidentified"
     );
@@ -73,7 +73,7 @@ describe("Monitoring : tracks and tags", () => {
   it("if a user tags a track then this is what should be used as the track tag", () => {
     const camera = "userTagged";
     cy.apiDeviceAdd(camera, group);
-    cy.testRecordingAddWithTestData(camera, {
+    cy.testUploadRecording(camera, {
       tracks: [{ tag: "cat" }],
     }).thenUserTagAs(Damian, "rabbit");
     cy.checkMonitoringTags(Damian, camera, ["rabbit"]);
@@ -82,27 +82,27 @@ describe("Monitoring : tracks and tags", () => {
   it("User tag is preferred over AI tag", () => {
     const camera = "userVsMultiple";
     cy.apiDeviceAdd(camera, group);
-    cy.testRecordingAddWithTestData(camera, {
+    cy.testUploadRecording(camera, {
       tags: ["possum", "rat", "rat"],
     }).thenUserTagAs(Damian, "rabbit");
-    cy.testRecordingAddWithTestData(camera, { tags: ["possum"] });
+    cy.testUploadRecording(camera, { tags: ["possum"] });
     cy.checkMonitoringTags(Damian, camera, ["rabbit"]);
   });
 
   it("When user tag and AI tag aggree", () => {
     const camera = "tagsagree";
     cy.apiDeviceAdd(camera, group);
-    cy.testRecordingAddWithTestData(camera, {
+    cy.testUploadRecording(camera, {
       tags: ["possum", "rat", "rat"],
     }).thenUserTagAs(Damian, "possum");
-    cy.testRecordingAddWithTestData(camera, { tags: ["possum"] });
+    cy.testUploadRecording(camera, { tags: ["possum"] });
     cy.checkMonitoringTags(Damian, camera, ["possum"]);
   });
 
   it("User animal tag is preferred over user unknown tag", () => {
     const camera = "userAnimalUnknown";
     cy.apiDeviceAdd(camera, group);
-    cy.testRecordingAddWithTestData(camera, {
+    cy.testUploadRecording(camera, {
       tags: ["unidentified", "unidentified", "unidentified"],
     }).then((recID: number) => {
       cy.testUserTagRecording(recID, 0, Damian, "possum");
@@ -116,7 +116,7 @@ describe("Monitoring : tracks and tags", () => {
     cy.apiUserAdd(Gerry);
     cy.apiGroupUserAdd(Damian, Gerry, group, true);
     cy.apiDeviceAdd(camera, group);
-    const recording = cy.testRecordingAddWithTestData(camera, {
+    const recording = cy.testUploadRecording(camera, {
       tags: ["possum", "rabbit"],
     });
     recording.then((recID: number) => {
@@ -128,17 +128,17 @@ describe("Monitoring : tracks and tags", () => {
   it("User tags conflict on one of many tracks majority wins", () => {
     const camera = "conflicter-multiple";
     cy.apiDeviceAdd(camera, group);
-    const recording = cy.testRecordingAddWithTestData(camera, {
+    const recording = cy.testUploadRecording(camera, {
       tags: ["possum", "rabbit"],
     });
     recording.then((recID: number) => {
       cy.testUserTagRecording(recID, 0, Damian, "possum");
       cy.testUserTagRecording(recID, 0, Gerry, "rat");
     });
-    cy.testRecordingAddWithTestData(camera, {
+    cy.testUploadRecording(camera, {
       tags: ["possum", "rat"],
     }).thenUserTagAs(Damian, "possum");
-    cy.testRecordingAddWithTestData(camera, { tags: ["cat"] }).thenUserTagAs(
+    cy.testUploadRecording(camera, { tags: ["cat"] }).thenUserTagAs(
       Damian,
       "possum"
     );

--- a/integration-tests/cypress/integration/api/recordings/monitoring_tags.ts
+++ b/integration-tests/cypress/integration/api/recordings/monitoring_tags.ts
@@ -7,7 +7,7 @@ describe("Monitoring : tracks and tags", () => {
   const group = "MonitoringTags";
 
   before(() => {
-    cy.apiCreateUserGroup(Damian, group);
+    cy.testCreateUserAndGroup(Damian, group);
   });
 
   // at the moment many tracks are being missed so we can't do this.
@@ -16,21 +16,21 @@ describe("Monitoring : tracks and tags", () => {
     const camera = "no_tracks";
     const notracks = [];
     const noVisits = [];
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     cy.uploadRecording(camera, { tracks: notracks });
     cy.checkMonitoring(Damian, camera, noVisits);
   });
 
   it("all automatic tags other than master are ignored - to prevent wallaby ai being used on other projects", () => {
     const camera = "only_master";
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     cy.uploadRecording(camera, { model: "different", tags: ["cat"] });
     cy.checkMonitoringTags(Damian, camera, ["none"]);
   });
 
   it("each recording contributes votes for what the animal is", () => {
     const camera = "multiple_tracks";
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     cy.uploadRecording(camera, { tags: ["possum", "rat"] });
     cy.uploadRecording(camera, { tags: ["cat"] });
     cy.uploadRecording(camera, { tags: ["cat"] });
@@ -39,7 +39,7 @@ describe("Monitoring : tracks and tags", () => {
 
   it("each track in a recording gets contributes a vote for what the animal is", () => {
     const camera = "multiple_tracks2";
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     cy.uploadRecording(camera, { tags: ["possum", "rat", "rat", "rat"] });
     cy.uploadRecording(camera, { tags: ["cat"] });
     cy.uploadRecording(camera, { tags: ["cat"] });
@@ -48,7 +48,7 @@ describe("Monitoring : tracks and tags", () => {
 
   it("track tag 'unidentified` is ignored when deciding label to use", () => {
     const camera = "has_unidentified";
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     cy.uploadRecording(camera, {
       tags: ["possum", "unidentified", "unidentified", "unidentified"],
     });
@@ -57,7 +57,7 @@ describe("Monitoring : tracks and tags", () => {
 
   it("What happens when user tags as 'unidentified`?", () => {
     const camera = "user_unidentified_tracks";
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     cy.uploadRecording(camera, { tags: ["possum"] }).thenUserTagAs(
       Damian,
       "unidentified"
@@ -67,7 +67,7 @@ describe("Monitoring : tracks and tags", () => {
 
   it("if a user tags a track then this is what should be used as the track tag", () => {
     const camera = "userTagged";
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     cy.uploadRecording(camera, { tracks: [{ tag: "cat" }] }).thenUserTagAs(
       Damian,
       "rabbit"
@@ -77,7 +77,7 @@ describe("Monitoring : tracks and tags", () => {
 
   it("User tag is preferred over AI tag", () => {
     const camera = "userVsMultiple";
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     cy.uploadRecording(camera, {
       tags: ["possum", "rat", "rat"],
     }).thenUserTagAs(Damian, "rabbit");
@@ -87,7 +87,7 @@ describe("Monitoring : tracks and tags", () => {
 
   it("When user tag and AI tag aggree", () => {
     const camera = "tagsagree";
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     cy.uploadRecording(camera, {
       tags: ["possum", "rat", "rat"],
     }).thenUserTagAs(Damian, "possum");
@@ -97,7 +97,7 @@ describe("Monitoring : tracks and tags", () => {
 
   it("User animal tag is preferred over user unknown tag", () => {
     const camera = "userAnimalUnknown";
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     cy.uploadRecording(camera, {
       tags: ["unidentified", "unidentified", "unidentified"],
     }).then((recID: number) => {
@@ -109,9 +109,9 @@ describe("Monitoring : tracks and tags", () => {
   });
   it("User tags conflict", () => {
     const camera = "conflicter";
-    cy.apiCreateUser(Gerry);
+    cy.apiUserAdd(Gerry);
     cy.apiGroupUserAdd(Damian, Gerry, group, true);
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     const recording = cy.uploadRecording(camera, {
       tags: ["possum", "rabbit"],
     });
@@ -123,7 +123,7 @@ describe("Monitoring : tracks and tags", () => {
   });
   it("User tags conflict on one of many tracks majority wins", () => {
     const camera = "conflicter-multiple";
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     const recording = cy.uploadRecording(camera, {
       tags: ["possum", "rabbit"],
     });

--- a/integration-tests/cypress/integration/api/recordings/monitoring_tags.ts
+++ b/integration-tests/cypress/integration/api/recordings/monitoring_tags.ts
@@ -110,7 +110,7 @@ describe("Monitoring : tracks and tags", () => {
   it("User tags conflict", () => {
     const camera = "conflicter";
     cy.apiCreateUser(Gerry);
-    cy.apiAddUserToGroup(Damian, Gerry, group, true);
+    cy.apiGroupUserAdd(Damian, Gerry, group, true);
     cy.apiCreateDevice(camera, group);
     const recording = cy.uploadRecording(camera, {
       tags: ["possum", "rabbit"],

--- a/integration-tests/cypress/integration/api/recordings/monitoring_times.ts
+++ b/integration-tests/cypress/integration/api/recordings/monitoring_times.ts
@@ -7,26 +7,26 @@ describe("Monitoring : times and recording groupings", () => {
   const group = "Monitoring_visits";
 
   before(() => {
-    cy.apiCreateUserGroup(Dexter, group);
+    cy.testCreateUserAndGroup(Dexter, group);
   });
 
   it("recordings less than 10 mins apart are considered a single visit", () => {
     const camera = "cam-close";
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     cy.uploadRecordingsAtTimes(camera, ["21:04", "21:13", "21:22"]);
     cy.checkMonitoring(Dexter, camera, [{ recordings: 3 }]);
   });
 
   it("recordings more 10 mins apart are different visits", () => {
     const camera = "cam-apart";
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     cy.uploadRecordingsAtTimes(camera, ["21:04", "21:15"]);
     cy.checkMonitoring(Dexter, camera, [{ recordings: 1 }, { recordings: 1 }]);
   });
 
   it("recordings exactly 10 mins apart end to start are different visits", () => {
     const camera = "cam-exactly-10-apart";
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     cy.uploadRecording(camera, { duration: 60 });
     cy.uploadRecording(camera, { minsLater: 11 });
     cy.checkMonitoring(Dexter, camera, [{ recordings: 1 }, { recordings: 1 }]);
@@ -34,7 +34,7 @@ describe("Monitoring : times and recording groupings", () => {
 
   it("recordings can start more than 10 mins apart so long as gap between one finishing and the next starting is less than 10 mins", () => {
     const camera = "cam-just-close";
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     cy.uploadRecording(camera, { duration: 61 });
     cy.uploadRecording(camera, { minsLater: 11 });
     cy.checkMonitoring(Dexter, camera, [{ recordings: 2 }]);
@@ -43,14 +43,14 @@ describe("Monitoring : times and recording groupings", () => {
   //  This feature has been disabled by Clare
   //    it("recordings with no tracks are not visits", () => {
   //    const camera = "cam-notracks";
-  //    cy.apiCreateDevice(camera, group);
+  //    cy.apiDeviceAdd(camera, group);
   //    cy.uploadRecording(camera, { tracks:[]});
   //    cy.checkMonitoring(Dexter, camera, []);
   //  });
 
   //    it("recordings with no tracks are not included in visits the fall within", () => {
   //    const camera = "cam-notracks-within-visit-timespan";
-  //    cy.apiCreateDevice(camera, group);
+  //    cy.apiDeviceAdd(camera, group);
   //    cy.uploadRecording(camera, { });
   //    cy.uploadRecording(camera, { minsLater: 5, tracks:[]});
   //    cy.uploadRecording(camera, { minsLater: 10});
@@ -59,7 +59,7 @@ describe("Monitoring : times and recording groupings", () => {
 
   it("Visits where the first recording is before the start time, but overlap with search period are marked as incomplete", () => {
     const camera = "cam-start-before";
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     cy.uploadRecording(camera, { time: "20:49", duration: 300 });
     cy.uploadRecording(camera, { time: "21:02" });
     cy.uploadRecording(camera, { time: "21:22" });
@@ -76,7 +76,7 @@ describe("Monitoring : times and recording groupings", () => {
 
   it("Visits where the first recording is just before the search period, but don't overlap with the search period are ignored.", () => {
     const camera = "cam-before-ignore";
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     cy.uploadRecording(camera, { time: "20:51" });
     cy.uploadRecording(camera, { time: "21:22" });
 
@@ -91,7 +91,7 @@ describe("Monitoring : times and recording groupings", () => {
 
   it("Visits where the last recording starts on period start time boundary is not included.", () => {
     const camera = "cam-start-boundary-case";
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     cy.uploadRecording(camera, { time: "20:40" });
     cy.uploadRecording(camera, { time: "20:50" });
     cy.uploadRecording(camera, { time: "21:00" });
@@ -105,7 +105,7 @@ describe("Monitoring : times and recording groupings", () => {
 
   it("Visits where the last recording ends on period end time boundary is included and complete.", () => {
     const camera = "cam-end-boundary-case";
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     cy.uploadRecording(camera, { time: "20:40" });
     cy.uploadRecording(camera, { time: "20:50" });
     cy.uploadRecording(camera, { time: "21:00" });
@@ -121,7 +121,7 @@ describe("Monitoring : times and recording groupings", () => {
 
   it("Visits which span the end-time but fall withing the collection window are included and marked as complete", () => {
     const camera = "cam-start-justbefore";
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     cy.uploadRecording(camera, { time: "20:59", duration: 300 });
     cy.uploadRecording(camera, { time: "21:05" });
 
@@ -136,7 +136,7 @@ describe("Monitoring : times and recording groupings", () => {
 
   it("Visits where the first recording is after the end time are ignored", () => {
     const camera = "cam-start-after";
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     cy.uploadRecording(camera, { time: "21:01", duration: 300 });
     cy.uploadRecording(camera, { time: "21:13" });
 
@@ -150,7 +150,7 @@ describe("Monitoring : times and recording groupings", () => {
   it("Visits where maybe there are even more recordings than collected are marked as incomplete", () => {
     const camera = "justLater";
     // add 12 recordings
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     cy.uploadRecording(camera, { time: "20:55", duration: 300 });
     for (let i = 0; i < 11; i++) {
       cy.uploadRecording(camera, { minsLater: 9 });
@@ -169,7 +169,7 @@ describe("Monitoring : times and recording groupings", () => {
   it("test start and end date of visits", () => {
     const camera = "dateTimes";
     const videoStart = new Date(2021, 1, 20, 21);
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     cy.uploadRecording(camera, {
       time: videoStart,
       duration: 15,
@@ -182,7 +182,7 @@ describe("Monitoring : times and recording groupings", () => {
   it("test start and end date of visits with multiple videos", () => {
     const camera = "dateTimes3";
     const videoStart = new Date(2021, 1, 20, 21);
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     cy.uploadRecording(camera, {
       time: videoStart,
       duration: 23,

--- a/integration-tests/cypress/integration/api/recordings/monitoring_times.ts
+++ b/integration-tests/cypress/integration/api/recordings/monitoring_times.ts
@@ -13,30 +13,30 @@ describe("Monitoring : times and recording groupings", () => {
   it("recordings less than 10 mins apart are considered a single visit", () => {
     const camera = "cam-close";
     cy.apiDeviceAdd(camera, group);
-    cy.uploadRecordingsAtTimes(camera, ["21:04", "21:13", "21:22"]);
+    cy.testAddRecordingsAtTimes(camera, ["21:04", "21:13", "21:22"]);
     cy.checkMonitoring(Dexter, camera, [{ recordings: 3 }]);
   });
 
   it("recordings more 10 mins apart are different visits", () => {
     const camera = "cam-apart";
     cy.apiDeviceAdd(camera, group);
-    cy.uploadRecordingsAtTimes(camera, ["21:04", "21:15"]);
+    cy.testAddRecordingsAtTimes(camera, ["21:04", "21:15"]);
     cy.checkMonitoring(Dexter, camera, [{ recordings: 1 }, { recordings: 1 }]);
   });
 
   it("recordings exactly 10 mins apart end to start are different visits", () => {
     const camera = "cam-exactly-10-apart";
     cy.apiDeviceAdd(camera, group);
-    cy.uploadRecording(camera, { duration: 60 });
-    cy.uploadRecording(camera, { minsLater: 11 });
+    cy.testRecordingAddWithTestData(camera, { duration: 60 });
+    cy.testRecordingAddWithTestData(camera, { minsLater: 11 });
     cy.checkMonitoring(Dexter, camera, [{ recordings: 1 }, { recordings: 1 }]);
   });
 
   it("recordings can start more than 10 mins apart so long as gap between one finishing and the next starting is less than 10 mins", () => {
     const camera = "cam-just-close";
     cy.apiDeviceAdd(camera, group);
-    cy.uploadRecording(camera, { duration: 61 });
-    cy.uploadRecording(camera, { minsLater: 11 });
+    cy.testRecordingAddWithTestData(camera, { duration: 61 });
+    cy.testRecordingAddWithTestData(camera, { minsLater: 11 });
     cy.checkMonitoring(Dexter, camera, [{ recordings: 2 }]);
   });
 
@@ -44,25 +44,25 @@ describe("Monitoring : times and recording groupings", () => {
   //    it("recordings with no tracks are not visits", () => {
   //    const camera = "cam-notracks";
   //    cy.apiDeviceAdd(camera, group);
-  //    cy.uploadRecording(camera, { tracks:[]});
+  //    cy.testRecordingAddWithTestData(camera, { tracks:[]});
   //    cy.checkMonitoring(Dexter, camera, []);
   //  });
 
   //    it("recordings with no tracks are not included in visits the fall within", () => {
   //    const camera = "cam-notracks-within-visit-timespan";
   //    cy.apiDeviceAdd(camera, group);
-  //    cy.uploadRecording(camera, { });
-  //    cy.uploadRecording(camera, { minsLater: 5, tracks:[]});
-  //    cy.uploadRecording(camera, { minsLater: 10});
+  //    cy.testRecordingAddWithTestData(camera, { });
+  //    cy.testRecordingAddWithTestData(camera, { minsLater: 5, tracks:[]});
+  //    cy.testRecordingAddWithTestData(camera, { minsLater: 10});
   //    cy.checkMonitoring(Dexter, camera, [{ recordings: 2 }]);
   //  });
 
   it("Visits where the first recording is before the start time, but overlap with search period are marked as incomplete", () => {
     const camera = "cam-start-before";
     cy.apiDeviceAdd(camera, group);
-    cy.uploadRecording(camera, { time: "20:49", duration: 300 });
-    cy.uploadRecording(camera, { time: "21:02" });
-    cy.uploadRecording(camera, { time: "21:22" });
+    cy.testRecordingAddWithTestData(camera, { time: "20:49", duration: 300 });
+    cy.testRecordingAddWithTestData(camera, { time: "21:02" });
+    cy.testRecordingAddWithTestData(camera, { time: "21:22" });
 
     const filter = {
       from: "21:00",
@@ -77,8 +77,8 @@ describe("Monitoring : times and recording groupings", () => {
   it("Visits where the first recording is just before the search period, but don't overlap with the search period are ignored.", () => {
     const camera = "cam-before-ignore";
     cy.apiDeviceAdd(camera, group);
-    cy.uploadRecording(camera, { time: "20:51" });
-    cy.uploadRecording(camera, { time: "21:22" });
+    cy.testRecordingAddWithTestData(camera, { time: "20:51" });
+    cy.testRecordingAddWithTestData(camera, { time: "21:22" });
 
     const filter = {
       from: "21:00",
@@ -92,9 +92,9 @@ describe("Monitoring : times and recording groupings", () => {
   it("Visits where the last recording starts on period start time boundary is not included.", () => {
     const camera = "cam-start-boundary-case";
     cy.apiDeviceAdd(camera, group);
-    cy.uploadRecording(camera, { time: "20:40" });
-    cy.uploadRecording(camera, { time: "20:50" });
-    cy.uploadRecording(camera, { time: "21:00" });
+    cy.testRecordingAddWithTestData(camera, { time: "20:40" });
+    cy.testRecordingAddWithTestData(camera, { time: "20:50" });
+    cy.testRecordingAddWithTestData(camera, { time: "21:00" });
 
     const filter = {
       from: "21:00",
@@ -106,9 +106,9 @@ describe("Monitoring : times and recording groupings", () => {
   it("Visits where the last recording ends on period end time boundary is included and complete.", () => {
     const camera = "cam-end-boundary-case";
     cy.apiDeviceAdd(camera, group);
-    cy.uploadRecording(camera, { time: "20:40" });
-    cy.uploadRecording(camera, { time: "20:50" });
-    cy.uploadRecording(camera, { time: "21:00" });
+    cy.testRecordingAddWithTestData(camera, { time: "20:40" });
+    cy.testRecordingAddWithTestData(camera, { time: "20:50" });
+    cy.testRecordingAddWithTestData(camera, { time: "21:00" });
 
     const filter = {
       until: "21:00",
@@ -122,8 +122,8 @@ describe("Monitoring : times and recording groupings", () => {
   it("Visits which span the end-time but fall withing the collection window are included and marked as complete", () => {
     const camera = "cam-start-justbefore";
     cy.apiDeviceAdd(camera, group);
-    cy.uploadRecording(camera, { time: "20:59", duration: 300 });
-    cy.uploadRecording(camera, { time: "21:05" });
+    cy.testRecordingAddWithTestData(camera, { time: "20:59", duration: 300 });
+    cy.testRecordingAddWithTestData(camera, { time: "21:05" });
 
     const filter = {
       until: "21:00",
@@ -137,8 +137,8 @@ describe("Monitoring : times and recording groupings", () => {
   it("Visits where the first recording is after the end time are ignored", () => {
     const camera = "cam-start-after";
     cy.apiDeviceAdd(camera, group);
-    cy.uploadRecording(camera, { time: "21:01", duration: 300 });
-    cy.uploadRecording(camera, { time: "21:13" });
+    cy.testRecordingAddWithTestData(camera, { time: "21:01", duration: 300 });
+    cy.testRecordingAddWithTestData(camera, { time: "21:13" });
 
     const filter = {
       until: "21:00",
@@ -151,9 +151,9 @@ describe("Monitoring : times and recording groupings", () => {
     const camera = "justLater";
     // add 12 recordings
     cy.apiDeviceAdd(camera, group);
-    cy.uploadRecording(camera, { time: "20:55", duration: 300 });
+    cy.testRecordingAddWithTestData(camera, { time: "20:55", duration: 300 });
     for (let i = 0; i < 11; i++) {
-      cy.uploadRecording(camera, { minsLater: 9 });
+      cy.testRecordingAddWithTestData(camera, { minsLater: 9 });
     }
 
     const filter = {
@@ -170,7 +170,7 @@ describe("Monitoring : times and recording groupings", () => {
     const camera = "dateTimes";
     const videoStart = new Date(2021, 1, 20, 21);
     cy.apiDeviceAdd(camera, group);
-    cy.uploadRecording(camera, {
+    cy.testRecordingAddWithTestData(camera, {
       time: videoStart,
       duration: 15,
     });
@@ -183,11 +183,11 @@ describe("Monitoring : times and recording groupings", () => {
     const camera = "dateTimes3";
     const videoStart = new Date(2021, 1, 20, 21);
     cy.apiDeviceAdd(camera, group);
-    cy.uploadRecording(camera, {
+    cy.testRecordingAddWithTestData(camera, {
       time: videoStart,
       duration: 23,
     });
-    cy.uploadRecording(camera, {
+    cy.testRecordingAddWithTestData(camera, {
       secsLater: 66,
       duration: 41,
     });

--- a/integration-tests/cypress/integration/api/recordings/monitoring_times.ts
+++ b/integration-tests/cypress/integration/api/recordings/monitoring_times.ts
@@ -27,16 +27,16 @@ describe("Monitoring : times and recording groupings", () => {
   it("recordings exactly 10 mins apart end to start are different visits", () => {
     const camera = "cam-exactly-10-apart";
     cy.apiDeviceAdd(camera, group);
-    cy.testRecordingAddWithTestData(camera, { duration: 60 });
-    cy.testRecordingAddWithTestData(camera, { minsLater: 11 });
+    cy.testUploadRecording(camera, { duration: 60 });
+    cy.testUploadRecording(camera, { minsLater: 11 });
     cy.checkMonitoring(Dexter, camera, [{ recordings: 1 }, { recordings: 1 }]);
   });
 
   it("recordings can start more than 10 mins apart so long as gap between one finishing and the next starting is less than 10 mins", () => {
     const camera = "cam-just-close";
     cy.apiDeviceAdd(camera, group);
-    cy.testRecordingAddWithTestData(camera, { duration: 61 });
-    cy.testRecordingAddWithTestData(camera, { minsLater: 11 });
+    cy.testUploadRecording(camera, { duration: 61 });
+    cy.testUploadRecording(camera, { minsLater: 11 });
     cy.checkMonitoring(Dexter, camera, [{ recordings: 2 }]);
   });
 
@@ -44,25 +44,25 @@ describe("Monitoring : times and recording groupings", () => {
   //    it("recordings with no tracks are not visits", () => {
   //    const camera = "cam-notracks";
   //    cy.apiDeviceAdd(camera, group);
-  //    cy.testRecordingAddWithTestData(camera, { tracks:[]});
+  //    cy.testUploadRecording(camera, { tracks:[]});
   //    cy.checkMonitoring(Dexter, camera, []);
   //  });
 
   //    it("recordings with no tracks are not included in visits the fall within", () => {
   //    const camera = "cam-notracks-within-visit-timespan";
   //    cy.apiDeviceAdd(camera, group);
-  //    cy.testRecordingAddWithTestData(camera, { });
-  //    cy.testRecordingAddWithTestData(camera, { minsLater: 5, tracks:[]});
-  //    cy.testRecordingAddWithTestData(camera, { minsLater: 10});
+  //    cy.testUploadRecording(camera, { });
+  //    cy.testUploadRecording(camera, { minsLater: 5, tracks:[]});
+  //    cy.testUploadRecording(camera, { minsLater: 10});
   //    cy.checkMonitoring(Dexter, camera, [{ recordings: 2 }]);
   //  });
 
   it("Visits where the first recording is before the start time, but overlap with search period are marked as incomplete", () => {
     const camera = "cam-start-before";
     cy.apiDeviceAdd(camera, group);
-    cy.testRecordingAddWithTestData(camera, { time: "20:49", duration: 300 });
-    cy.testRecordingAddWithTestData(camera, { time: "21:02" });
-    cy.testRecordingAddWithTestData(camera, { time: "21:22" });
+    cy.testUploadRecording(camera, { time: "20:49", duration: 300 });
+    cy.testUploadRecording(camera, { time: "21:02" });
+    cy.testUploadRecording(camera, { time: "21:22" });
 
     const filter = {
       from: "21:00",
@@ -77,8 +77,8 @@ describe("Monitoring : times and recording groupings", () => {
   it("Visits where the first recording is just before the search period, but don't overlap with the search period are ignored.", () => {
     const camera = "cam-before-ignore";
     cy.apiDeviceAdd(camera, group);
-    cy.testRecordingAddWithTestData(camera, { time: "20:51" });
-    cy.testRecordingAddWithTestData(camera, { time: "21:22" });
+    cy.testUploadRecording(camera, { time: "20:51" });
+    cy.testUploadRecording(camera, { time: "21:22" });
 
     const filter = {
       from: "21:00",
@@ -92,9 +92,9 @@ describe("Monitoring : times and recording groupings", () => {
   it("Visits where the last recording starts on period start time boundary is not included.", () => {
     const camera = "cam-start-boundary-case";
     cy.apiDeviceAdd(camera, group);
-    cy.testRecordingAddWithTestData(camera, { time: "20:40" });
-    cy.testRecordingAddWithTestData(camera, { time: "20:50" });
-    cy.testRecordingAddWithTestData(camera, { time: "21:00" });
+    cy.testUploadRecording(camera, { time: "20:40" });
+    cy.testUploadRecording(camera, { time: "20:50" });
+    cy.testUploadRecording(camera, { time: "21:00" });
 
     const filter = {
       from: "21:00",
@@ -106,9 +106,9 @@ describe("Monitoring : times and recording groupings", () => {
   it("Visits where the last recording ends on period end time boundary is included and complete.", () => {
     const camera = "cam-end-boundary-case";
     cy.apiDeviceAdd(camera, group);
-    cy.testRecordingAddWithTestData(camera, { time: "20:40" });
-    cy.testRecordingAddWithTestData(camera, { time: "20:50" });
-    cy.testRecordingAddWithTestData(camera, { time: "21:00" });
+    cy.testUploadRecording(camera, { time: "20:40" });
+    cy.testUploadRecording(camera, { time: "20:50" });
+    cy.testUploadRecording(camera, { time: "21:00" });
 
     const filter = {
       until: "21:00",
@@ -122,8 +122,8 @@ describe("Monitoring : times and recording groupings", () => {
   it("Visits which span the end-time but fall withing the collection window are included and marked as complete", () => {
     const camera = "cam-start-justbefore";
     cy.apiDeviceAdd(camera, group);
-    cy.testRecordingAddWithTestData(camera, { time: "20:59", duration: 300 });
-    cy.testRecordingAddWithTestData(camera, { time: "21:05" });
+    cy.testUploadRecording(camera, { time: "20:59", duration: 300 });
+    cy.testUploadRecording(camera, { time: "21:05" });
 
     const filter = {
       until: "21:00",
@@ -137,8 +137,8 @@ describe("Monitoring : times and recording groupings", () => {
   it("Visits where the first recording is after the end time are ignored", () => {
     const camera = "cam-start-after";
     cy.apiDeviceAdd(camera, group);
-    cy.testRecordingAddWithTestData(camera, { time: "21:01", duration: 300 });
-    cy.testRecordingAddWithTestData(camera, { time: "21:13" });
+    cy.testUploadRecording(camera, { time: "21:01", duration: 300 });
+    cy.testUploadRecording(camera, { time: "21:13" });
 
     const filter = {
       until: "21:00",
@@ -151,9 +151,9 @@ describe("Monitoring : times and recording groupings", () => {
     const camera = "justLater";
     // add 12 recordings
     cy.apiDeviceAdd(camera, group);
-    cy.testRecordingAddWithTestData(camera, { time: "20:55", duration: 300 });
+    cy.testUploadRecording(camera, { time: "20:55", duration: 300 });
     for (let i = 0; i < 11; i++) {
-      cy.testRecordingAddWithTestData(camera, { minsLater: 9 });
+      cy.testUploadRecording(camera, { minsLater: 9 });
     }
 
     const filter = {
@@ -170,7 +170,7 @@ describe("Monitoring : times and recording groupings", () => {
     const camera = "dateTimes";
     const videoStart = new Date(2021, 1, 20, 21);
     cy.apiDeviceAdd(camera, group);
-    cy.testRecordingAddWithTestData(camera, {
+    cy.testUploadRecording(camera, {
       time: videoStart,
       duration: 15,
     });
@@ -183,11 +183,11 @@ describe("Monitoring : times and recording groupings", () => {
     const camera = "dateTimes3";
     const videoStart = new Date(2021, 1, 20, 21);
     cy.apiDeviceAdd(camera, group);
-    cy.testRecordingAddWithTestData(camera, {
+    cy.testUploadRecording(camera, {
       time: videoStart,
       duration: 23,
     });
-    cy.testRecordingAddWithTestData(camera, {
+    cy.testUploadRecording(camera, {
       secsLater: 66,
       duration: 41,
     });

--- a/integration-tests/cypress/integration/api/recordings/recordings_stations.ts
+++ b/integration-tests/cypress/integration/api/recordings/recordings_stations.ts
@@ -4,27 +4,27 @@ describe("Stations: add and remove", () => {
   const Josie = "Josie_stations";
   const group = "add_stations";
   const forestLatLong = { lat: -43.62367659982, lng: 172.62646754804 };
-  const date = new Date(2021, 3, 25, 21);
-  const earlier = new Date(2021, 3, 25, 20);
-  const later = new Date(2021, 3, 25, 22);
+  const date = new Date(2021, 3, 25, 21).toISOString();
+  const earlier = new Date(2021, 3, 25, 20).toISOString();
+  const later = new Date(2021, 3, 25, 22).toISOString();
 
   before(() => {
-    cy.apiCreateUserGroup(Josie, group);
+    cy.testCreateUserAndGroup(Josie, group);
     const stations = [
       { name: "forest", lat: -43.62367659982, lng: 172.62646754804 },
       { name: "stream", lat: -43.62367659983, lng: 172.62646754804 },
     ];
-    cy.apiGroupsStationsUpdate(Josie, group, stations);
+    cy.apiGroupStationsUpdate(Josie, group, stations);
   });
 
   it.skip("recordings are assigned to the correct stations", () => {
-    cy.apiCreateDevice("in-forest", group);
+    cy.apiDeviceAdd("in-forest", group);
     cy.uploadRecording("in-forest", forestLatLong).thenCheckStationIs(
       Josie,
       "forest"
     );
 
-    cy.apiCreateDevice("in-stream", group);
+    cy.apiDeviceAdd("in-stream", group);
     cy.uploadRecording("in-stream", {
       lat: -43.62367659983,
       lng: 172.62646754804,
@@ -32,7 +32,7 @@ describe("Stations: add and remove", () => {
   });
 
   it("recording that is not close to any station is not assigned a station", () => {
-    cy.apiCreateDevice("neither", group);
+    cy.apiDeviceAdd("neither", group);
     cy.uploadRecording("neither", {
       lat: -43.6,
       lng: 172.6,
@@ -43,7 +43,7 @@ describe("Stations: add and remove", () => {
     const otherGroup = "Josies-other";
     const camera = "other-group";
     cy.apiGroupAdd(Josie, otherGroup);
-    cy.apiCreateDevice(camera, otherGroup);
+    cy.apiDeviceAdd(camera, otherGroup);
     cy.uploadRecording(camera, forestLatLong).thenCheckStationIs(Josie, "");
   });
 
@@ -51,7 +51,7 @@ describe("Stations: add and remove", () => {
     const Josie2 = "Josie2";
     const groupUpdate = "update-stations";
     const camera = "update-after";
-    cy.apiCreateUserGroupAndDevice(Josie2, groupUpdate, camera);
+    cy.testCreateUserGroupAndDevice(Josie2, groupUpdate, camera);
     cy.uploadRecording(camera, { time: date, lat: -43.6, lng: 172.8 });
     cy.checkRecordingsStationIs(Josie2, "");
 
@@ -59,7 +59,7 @@ describe("Stations: add and remove", () => {
       { name: "forest", lat: -43.62367659982, lng: 172.62646754804 },
       { name: "waterfall", lat: -43.6, lng: 172.8 },
     ];
-    cy.apiGroupsStationsUpdate(Josie2, groupUpdate, stations, later);
+    cy.apiGroupStationsUpdate(Josie2, groupUpdate, stations, later);
     cy.checkRecordingsStationIs(Josie2, "");
   });
 
@@ -67,7 +67,7 @@ describe("Stations: add and remove", () => {
     const Josie3 = "Josie3";
     const camera = "update-earlier";
     const groupNotUpdate = "not-update-stations";
-    cy.apiCreateUserGroupAndDevice(Josie3, groupNotUpdate, camera);
+    cy.testCreateUserGroupAndDevice(Josie3, groupNotUpdate, camera);
     cy.uploadRecording(camera, { time: date, lat: -43.6, lng: 172.8 });
     cy.checkRecordingsStationIs(Josie3, "");
 
@@ -75,7 +75,7 @@ describe("Stations: add and remove", () => {
       { name: "forest", lat: -43.62367659982, lng: 172.62646754804 },
       { name: "waterfall", lat: -43.6, lng: 172.8 },
     ];
-    cy.apiGroupsStationsUpdate(Josie3, groupNotUpdate, stations, earlier);
+    cy.apiGroupStationsUpdate(Josie3, groupNotUpdate, stations, earlier);
     cy.checkRecordingsStationIs(Josie3, "waterfall");
   });
 
@@ -83,18 +83,18 @@ describe("Stations: add and remove", () => {
     const Josie4 = "Josie4";
     const camera = "update-remove";
     const groupRemove = "remove-station";
-    const date = new Date(2021, 3, 25, 21);
-    const earlier = new Date(2021, 3, 25, 20);
-    cy.apiCreateUserGroupAndDevice(Josie4, groupRemove, camera);
+    const date = new Date(2021, 3, 25, 21).toISOString();
+    const earlier = new Date(2021, 3, 25, 20).toISOString();
+    cy.testCreateUserGroupAndDevice(Josie4, groupRemove, camera);
     const stations = [{ name: "waterfall", lat: -43.6, lng: 172.8 }];
-    cy.apiGroupsStationsUpdate(Josie4, groupRemove, stations, earlier);
+    cy.apiGroupStationsUpdate(Josie4, groupRemove, stations, earlier);
     cy.uploadRecording(camera, { time: date, lat: -43.6, lng: 172.8 });
     cy.checkRecordingsStationIs(Josie4, "waterfall");
 
     const stations2 = [
       { name: "forest", lat: -43.62367659982, lng: 172.62646754804 },
     ];
-    cy.apiGroupsStationsUpdate(Josie4, groupRemove, stations2, earlier);
+    cy.apiGroupStationsUpdate(Josie4, groupRemove, stations2, earlier);
     cy.checkRecordingsStationIs(Josie4, "");
   });
 });

--- a/integration-tests/cypress/integration/api/recordings/recordings_stations.ts
+++ b/integration-tests/cypress/integration/api/recordings/recordings_stations.ts
@@ -4,9 +4,9 @@ describe("Stations: add and remove", () => {
   const Josie = "Josie_stations";
   const group = "add_stations";
   const forestLatLong = { lat: -43.62367659982, lng: 172.62646754804 };
-  const date = new Date(2021, 3, 25, 21).toISOString();
-  const earlier = new Date(2021, 3, 25, 20).toISOString();
-  const later = new Date(2021, 3, 25, 22).toISOString();
+  const date = "2021-05-25T09:01:00.000Z";
+  const earlier = "2021-05-25T08:00:00.000Z";
+  const later = "2021-05-25T10:00:00.000Z";
 
   before(() => {
     cy.testCreateUserAndGroup(Josie, group);
@@ -52,7 +52,7 @@ describe("Stations: add and remove", () => {
     const groupUpdate = "update-stations";
     const camera = "update-after";
     cy.testCreateUserGroupAndDevice(Josie2, groupUpdate, camera);
-    cy.uploadRecording(camera, { time: date, lat: -43.6, lng: 172.8 });
+    cy.uploadRecording(camera, { time: new Date(date), lat: -43.6, lng: 172.8 });
     cy.checkRecordingsStationIs(Josie2, "");
 
     const stations = [
@@ -68,7 +68,7 @@ describe("Stations: add and remove", () => {
     const camera = "update-earlier";
     const groupNotUpdate = "not-update-stations";
     cy.testCreateUserGroupAndDevice(Josie3, groupNotUpdate, camera);
-    cy.uploadRecording(camera, { time: date, lat: -43.6, lng: 172.8 });
+    cy.uploadRecording(camera, { time: new Date(date), lat: -43.6, lng: 172.8 });
     cy.checkRecordingsStationIs(Josie3, "");
 
     const stations = [
@@ -83,12 +83,12 @@ describe("Stations: add and remove", () => {
     const Josie4 = "Josie4";
     const camera = "update-remove";
     const groupRemove = "remove-station";
-    const date = new Date(2021, 3, 25, 21).toISOString();
-    const earlier = new Date(2021, 3, 25, 20).toISOString();
+    const date = "2021-03-25T21:01:00.000Z";
+    const earlier = "2021-03-25T20:01:00.000Z";
     cy.testCreateUserGroupAndDevice(Josie4, groupRemove, camera);
     const stations = [{ name: "waterfall", lat: -43.6, lng: 172.8 }];
     cy.apiGroupStationsUpdate(Josie4, groupRemove, stations, earlier);
-    cy.uploadRecording(camera, { time: date, lat: -43.6, lng: 172.8 });
+    cy.uploadRecording(camera, { time: new Date(date), lat: -43.6, lng: 172.8 });
     cy.checkRecordingsStationIs(Josie4, "waterfall");
 
     const stations2 = [

--- a/integration-tests/cypress/integration/api/recordings/recordings_stations.ts
+++ b/integration-tests/cypress/integration/api/recordings/recordings_stations.ts
@@ -19,13 +19,13 @@ describe("Stations: add and remove", () => {
 
   it.skip("recordings are assigned to the correct stations", () => {
     cy.apiDeviceAdd("in-forest", group);
-    cy.testRecordingAddWithTestData(
+    cy.testUploadRecording(
       "in-forest",
       forestLatLong
     ).thenCheckStationIs(Josie, "forest");
 
     cy.apiDeviceAdd("in-stream", group);
-    cy.testRecordingAddWithTestData("in-stream", {
+    cy.testUploadRecording("in-stream", {
       lat: -43.62367659983,
       lng: 172.62646754804,
     }).thenCheckStationIs(Josie, "stream");
@@ -33,7 +33,7 @@ describe("Stations: add and remove", () => {
 
   it("recording that is not close to any station is not assigned a station", () => {
     cy.apiDeviceAdd("neither", group);
-    cy.testRecordingAddWithTestData("neither", {
+    cy.testUploadRecording("neither", {
       lat: -43.6,
       lng: 172.6,
     }).thenCheckStationIs(Josie, "");
@@ -44,7 +44,7 @@ describe("Stations: add and remove", () => {
     const camera = "other-group";
     cy.apiGroupAdd(Josie, otherGroup);
     cy.apiDeviceAdd(camera, otherGroup);
-    cy.testRecordingAddWithTestData(camera, forestLatLong).thenCheckStationIs(
+    cy.testUploadRecording(camera, forestLatLong).thenCheckStationIs(
       Josie,
       ""
     );
@@ -55,7 +55,7 @@ describe("Stations: add and remove", () => {
     const groupUpdate = "update-stations";
     const camera = "update-after";
     cy.testCreateUserGroupAndDevice(Josie2, groupUpdate, camera);
-    cy.testRecordingAddWithTestData(camera, {
+    cy.testUploadRecording(camera, {
       time: new Date(date),
       lat: -43.6,
       lng: 172.8,
@@ -75,7 +75,7 @@ describe("Stations: add and remove", () => {
     const camera = "update-earlier";
     const groupNotUpdate = "not-update-stations";
     cy.testCreateUserGroupAndDevice(Josie3, groupNotUpdate, camera);
-    cy.testRecordingAddWithTestData(camera, {
+    cy.testUploadRecording(camera, {
       time: new Date(date),
       lat: -43.6,
       lng: 172.8,
@@ -99,7 +99,7 @@ describe("Stations: add and remove", () => {
     cy.testCreateUserGroupAndDevice(Josie4, groupRemove, camera);
     const stations = [{ name: "waterfall", lat: -43.6, lng: 172.8 }];
     cy.apiGroupStationsUpdate(Josie4, groupRemove, stations, earlier);
-    cy.testRecordingAddWithTestData(camera, {
+    cy.testUploadRecording(camera, {
       time: new Date(date),
       lat: -43.6,
       lng: 172.8,

--- a/integration-tests/cypress/integration/api/recordings/recordings_stations.ts
+++ b/integration-tests/cypress/integration/api/recordings/recordings_stations.ts
@@ -19,13 +19,13 @@ describe("Stations: add and remove", () => {
 
   it.skip("recordings are assigned to the correct stations", () => {
     cy.apiDeviceAdd("in-forest", group);
-    cy.uploadRecording("in-forest", forestLatLong).thenCheckStationIs(
-      Josie,
-      "forest"
-    );
+    cy.testRecordingAddWithTestData(
+      "in-forest",
+      forestLatLong
+    ).thenCheckStationIs(Josie, "forest");
 
     cy.apiDeviceAdd("in-stream", group);
-    cy.uploadRecording("in-stream", {
+    cy.testRecordingAddWithTestData("in-stream", {
       lat: -43.62367659983,
       lng: 172.62646754804,
     }).thenCheckStationIs(Josie, "stream");
@@ -33,7 +33,7 @@ describe("Stations: add and remove", () => {
 
   it("recording that is not close to any station is not assigned a station", () => {
     cy.apiDeviceAdd("neither", group);
-    cy.uploadRecording("neither", {
+    cy.testRecordingAddWithTestData("neither", {
       lat: -43.6,
       lng: 172.6,
     }).thenCheckStationIs(Josie, "");
@@ -44,7 +44,10 @@ describe("Stations: add and remove", () => {
     const camera = "other-group";
     cy.apiGroupAdd(Josie, otherGroup);
     cy.apiDeviceAdd(camera, otherGroup);
-    cy.uploadRecording(camera, forestLatLong).thenCheckStationIs(Josie, "");
+    cy.testRecordingAddWithTestData(camera, forestLatLong).thenCheckStationIs(
+      Josie,
+      ""
+    );
   });
 
   it("recordings are not updated if before date specified", () => {
@@ -52,7 +55,11 @@ describe("Stations: add and remove", () => {
     const groupUpdate = "update-stations";
     const camera = "update-after";
     cy.testCreateUserGroupAndDevice(Josie2, groupUpdate, camera);
-    cy.uploadRecording(camera, { time: new Date(date), lat: -43.6, lng: 172.8 });
+    cy.testRecordingAddWithTestData(camera, {
+      time: new Date(date),
+      lat: -43.6,
+      lng: 172.8,
+    });
     cy.checkRecordingsStationIs(Josie2, "");
 
     const stations = [
@@ -68,7 +75,11 @@ describe("Stations: add and remove", () => {
     const camera = "update-earlier";
     const groupNotUpdate = "not-update-stations";
     cy.testCreateUserGroupAndDevice(Josie3, groupNotUpdate, camera);
-    cy.uploadRecording(camera, { time: new Date(date), lat: -43.6, lng: 172.8 });
+    cy.testRecordingAddWithTestData(camera, {
+      time: new Date(date),
+      lat: -43.6,
+      lng: 172.8,
+    });
     cy.checkRecordingsStationIs(Josie3, "");
 
     const stations = [
@@ -88,7 +99,11 @@ describe("Stations: add and remove", () => {
     cy.testCreateUserGroupAndDevice(Josie4, groupRemove, camera);
     const stations = [{ name: "waterfall", lat: -43.6, lng: 172.8 }];
     cy.apiGroupStationsUpdate(Josie4, groupRemove, stations, earlier);
-    cy.uploadRecording(camera, { time: new Date(date), lat: -43.6, lng: 172.8 });
+    cy.testRecordingAddWithTestData(camera, {
+      time: new Date(date),
+      lat: -43.6,
+      lng: 172.8,
+    });
     cy.checkRecordingsStationIs(Josie4, "waterfall");
 
     const stations2 = [

--- a/integration-tests/cypress/integration/api/recordings/recordings_stations.ts
+++ b/integration-tests/cypress/integration/api/recordings/recordings_stations.ts
@@ -14,7 +14,7 @@ describe("Stations: add and remove", () => {
       { name: "forest", lat: -43.62367659982, lng: 172.62646754804 },
       { name: "stream", lat: -43.62367659983, lng: 172.62646754804 },
     ];
-    cy.apiUploadStations(Josie, group, stations);
+    cy.apiGroupsStationsUpdate(Josie, group, stations);
   });
 
   it.skip("recordings are assigned to the correct stations", () => {
@@ -42,7 +42,7 @@ describe("Stations: add and remove", () => {
   it("recordings in another group are not assigned a station", () => {
     const otherGroup = "Josies-other";
     const camera = "other-group";
-    cy.apiCreateGroup(Josie, otherGroup);
+    cy.apiGroupAdd(Josie, otherGroup);
     cy.apiCreateDevice(camera, otherGroup);
     cy.uploadRecording(camera, forestLatLong).thenCheckStationIs(Josie, "");
   });
@@ -59,7 +59,7 @@ describe("Stations: add and remove", () => {
       { name: "forest", lat: -43.62367659982, lng: 172.62646754804 },
       { name: "waterfall", lat: -43.6, lng: 172.8 },
     ];
-    cy.apiUploadStations(Josie2, groupUpdate, stations, later);
+    cy.apiGroupsStationsUpdate(Josie2, groupUpdate, stations, later);
     cy.checkRecordingsStationIs(Josie2, "");
   });
 
@@ -75,7 +75,7 @@ describe("Stations: add and remove", () => {
       { name: "forest", lat: -43.62367659982, lng: 172.62646754804 },
       { name: "waterfall", lat: -43.6, lng: 172.8 },
     ];
-    cy.apiUploadStations(Josie3, groupNotUpdate, stations, earlier);
+    cy.apiGroupsStationsUpdate(Josie3, groupNotUpdate, stations, earlier);
     cy.checkRecordingsStationIs(Josie3, "waterfall");
   });
 
@@ -87,14 +87,14 @@ describe("Stations: add and remove", () => {
     const earlier = new Date(2021, 3, 25, 20);
     cy.apiCreateUserGroupAndDevice(Josie4, groupRemove, camera);
     const stations = [{ name: "waterfall", lat: -43.6, lng: 172.8 }];
-    cy.apiUploadStations(Josie4, groupRemove, stations, earlier);
+    cy.apiGroupsStationsUpdate(Josie4, groupRemove, stations, earlier);
     cy.uploadRecording(camera, { time: date, lat: -43.6, lng: 172.8 });
     cy.checkRecordingsStationIs(Josie4, "waterfall");
 
     const stations2 = [
       { name: "forest", lat: -43.62367659982, lng: 172.62646754804 },
     ];
-    cy.apiUploadStations(Josie4, groupRemove, stations2, earlier);
+    cy.apiGroupsStationsUpdate(Josie4, groupRemove, stations2, earlier);
     cy.checkRecordingsStationIs(Josie4, "");
   });
 });

--- a/integration-tests/cypress/integration/api/recordings/visit_tags.ts
+++ b/integration-tests/cypress/integration/api/recordings/visit_tags.ts
@@ -15,39 +15,44 @@ describe("Visits : tracks and tags", () => {
     const notracks = [];
     const noVisits = [];
     cy.apiDeviceAdd(camera, group);
-    cy.uploadRecording(camera, { tracks: notracks });
+    cy.testRecordingAddWithTestData(camera, { tracks: notracks });
     cy.checkVisits(Dee, camera, noVisits);
   });
 
   it("all automatic tags other than master are ignored - to prevent wallaby ai being used on other projects", () => {
     const camera = "only_master";
     cy.apiDeviceAdd(camera, group);
-    cy.uploadRecording(camera, { model: "different", tags: ["cat"] });
+    cy.testRecordingAddWithTestData(camera, {
+      model: "different",
+      tags: ["cat"],
+    });
     cy.checkVisitTags(Dee, camera, ["<null>"]);
   });
 
   it("each recording contributes a vote for what the animal is", () => {
     const camera = "multiple_tracks";
     cy.apiDeviceAdd(camera, group);
-    cy.uploadRecording(camera, { tags: ["possum", "rat"] });
-    cy.uploadRecording(camera, { tags: ["cat"] });
-    cy.uploadRecording(camera, { tags: ["cat"] });
+    cy.testRecordingAddWithTestData(camera, { tags: ["possum", "rat"] });
+    cy.testRecordingAddWithTestData(camera, { tags: ["cat"] });
+    cy.testRecordingAddWithTestData(camera, { tags: ["cat"] });
     cy.checkVisitTags(Dee, camera, ["cat"]);
   });
 
   it("each track in a recording gets contributes a vote for what the animal is", () => {
     const camera = "multiple_tracks2";
     cy.apiDeviceAdd(camera, group);
-    cy.uploadRecording(camera, { tags: ["possum", "rat", "rat", "rat"] });
-    cy.uploadRecording(camera, { tags: ["cat"] });
-    cy.uploadRecording(camera, { tags: ["cat"] });
+    cy.testRecordingAddWithTestData(camera, {
+      tags: ["possum", "rat", "rat", "rat"],
+    });
+    cy.testRecordingAddWithTestData(camera, { tags: ["cat"] });
+    cy.testRecordingAddWithTestData(camera, { tags: ["cat"] });
     cy.checkVisitTags(Dee, camera, ["rat"]);
   });
 
   it("track tag 'unidentified` is ignored when deciding label to use", () => {
     const camera = "has_unidentified";
     cy.apiDeviceAdd(camera, group);
-    cy.uploadRecording(camera, {
+    cy.testRecordingAddWithTestData(camera, {
       tags: ["possum", "unidentified", "unidentified", "unidentified"],
     });
     cy.checkVisitTags(Dee, camera, ["possum"]);
@@ -56,7 +61,7 @@ describe("Visits : tracks and tags", () => {
   it("What happens when user tags as 'unidentified`?", () => {
     const camera = "user_unidentified_tracks";
     cy.apiDeviceAdd(camera, group);
-    cy.uploadRecording(camera, { tags: ["possum"] }).thenUserTagAs(
+    cy.testRecordingAddWithTestData(camera, { tags: ["possum"] }).thenUserTagAs(
       Dee,
       "unidentified"
     );
@@ -66,33 +71,32 @@ describe("Visits : tracks and tags", () => {
   it("if a user tags a track then this is what should be used as the track tag", () => {
     const camera = "userTagged";
     cy.apiDeviceAdd(camera, group);
-    cy.uploadRecording(camera, { tracks: [{ tag: "cat" }] }).thenUserTagAs(
-      Dee,
-      "rabbit"
-    );
+    cy.testRecordingAddWithTestData(camera, {
+      tracks: [{ tag: "cat" }],
+    }).thenUserTagAs(Dee, "rabbit");
     cy.checkVisitTags(Dee, camera, ["rabbit"]);
   });
 
   it("User tag is preferred over AI tag", () => {
     const camera = "userVsMultiple";
     cy.apiDeviceAdd(camera, group);
-    cy.uploadRecording(camera, {
+    cy.testRecordingAddWithTestData(camera, {
       time: new Date(2021, 1, 20, 21),
       tags: ["possum", "rat", "rat"],
     }).thenUserTagAs(Dee, "rabbit");
-    cy.uploadRecording(camera, { tags: ["possum"] });
+    cy.testRecordingAddWithTestData(camera, { tags: ["possum"] });
     cy.checkVisitTags(Dee, camera, ["rabbit"]);
   });
 
   it("User animal tag is preferred over user unknown tag", () => {
     const camera = "userAnimalUnknown";
     cy.apiDeviceAdd(camera, group);
-    cy.uploadRecording(camera, {
+    cy.testRecordingAddWithTestData(camera, {
       tags: ["unidentified", "unidentified", "unidentified"],
     }).then((recID: number) => {
-      cy.userTagRecording(recID, 0, Dee, "possum");
-      cy.userTagRecording(recID, 1, Dee, "unknown");
-      cy.userTagRecording(recID, 2, Dee, "unknown");
+      cy.testUserTagRecording(recID, 0, Dee, "possum");
+      cy.testUserTagRecording(recID, 1, Dee, "unknown");
+      cy.testUserTagRecording(recID, 2, Dee, "unknown");
     });
     cy.checkVisitTags(Dee, camera, ["possum"]);
   });
@@ -101,13 +105,13 @@ describe("Visits : tracks and tags", () => {
     cy.apiUserAdd(Gee);
     cy.apiGroupUserAdd(Dee, Gee, group, true);
     cy.apiDeviceAdd(camera, group);
-    const recording = cy.uploadRecording(camera, {
+    const recording = cy.testRecordingAddWithTestData(camera, {
       time: new Date(2021, 1, 20, 21),
       tags: ["possum"],
     });
     recording.then((recID: number) => {
-      cy.userTagRecording(recID, 0, Dee, "possum");
-      cy.userTagRecording(recID, 0, Gee, "rat");
+      cy.testUserTagRecording(recID, 0, Dee, "possum");
+      cy.testUserTagRecording(recID, 0, Gee, "rat");
     });
     cy.checkVisitTags(Dee, camera, ["conflicting tags"]);
   });

--- a/integration-tests/cypress/integration/api/recordings/visit_tags.ts
+++ b/integration-tests/cypress/integration/api/recordings/visit_tags.ts
@@ -7,28 +7,28 @@ describe("Visits : tracks and tags", () => {
   const group = "VisitTags";
 
   before(() => {
-    cy.apiCreateUserGroup(Dee, group);
+    cy.testCreateUserAndGroup(Dee, group);
   });
 
   it("recordings with no tracks do not create a visit", () => {
     const camera = "no_tracks";
     const notracks = [];
     const noVisits = [];
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     cy.uploadRecording(camera, { tracks: notracks });
     cy.checkVisits(Dee, camera, noVisits);
   });
 
   it("all automatic tags other than master are ignored - to prevent wallaby ai being used on other projects", () => {
     const camera = "only_master";
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     cy.uploadRecording(camera, { model: "different", tags: ["cat"] });
     cy.checkVisitTags(Dee, camera, ["<null>"]);
   });
 
   it("each recording contributes a vote for what the animal is", () => {
     const camera = "multiple_tracks";
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     cy.uploadRecording(camera, { tags: ["possum", "rat"] });
     cy.uploadRecording(camera, { tags: ["cat"] });
     cy.uploadRecording(camera, { tags: ["cat"] });
@@ -37,7 +37,7 @@ describe("Visits : tracks and tags", () => {
 
   it("each track in a recording gets contributes a vote for what the animal is", () => {
     const camera = "multiple_tracks2";
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     cy.uploadRecording(camera, { tags: ["possum", "rat", "rat", "rat"] });
     cy.uploadRecording(camera, { tags: ["cat"] });
     cy.uploadRecording(camera, { tags: ["cat"] });
@@ -46,7 +46,7 @@ describe("Visits : tracks and tags", () => {
 
   it("track tag 'unidentified` is ignored when deciding label to use", () => {
     const camera = "has_unidentified";
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     cy.uploadRecording(camera, {
       tags: ["possum", "unidentified", "unidentified", "unidentified"],
     });
@@ -55,7 +55,7 @@ describe("Visits : tracks and tags", () => {
 
   it("What happens when user tags as 'unidentified`?", () => {
     const camera = "user_unidentified_tracks";
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     cy.uploadRecording(camera, { tags: ["possum"] }).thenUserTagAs(
       Dee,
       "unidentified"
@@ -65,7 +65,7 @@ describe("Visits : tracks and tags", () => {
 
   it("if a user tags a track then this is what should be used as the track tag", () => {
     const camera = "userTagged";
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     cy.uploadRecording(camera, { tracks: [{ tag: "cat" }] }).thenUserTagAs(
       Dee,
       "rabbit"
@@ -75,7 +75,7 @@ describe("Visits : tracks and tags", () => {
 
   it("User tag is preferred over AI tag", () => {
     const camera = "userVsMultiple";
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     cy.uploadRecording(camera, {
       time: new Date(2021, 1, 20, 21),
       tags: ["possum", "rat", "rat"],
@@ -86,7 +86,7 @@ describe("Visits : tracks and tags", () => {
 
   it("User animal tag is preferred over user unknown tag", () => {
     const camera = "userAnimalUnknown";
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     cy.uploadRecording(camera, {
       tags: ["unidentified", "unidentified", "unidentified"],
     }).then((recID: number) => {
@@ -98,9 +98,9 @@ describe("Visits : tracks and tags", () => {
   });
   it("User tags conflict", () => {
     const camera = "conflicter";
-    cy.apiCreateUser(Gee);
+    cy.apiUserAdd(Gee);
     cy.apiGroupUserAdd(Dee, Gee, group, true);
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     const recording = cy.uploadRecording(camera, {
       time: new Date(2021, 1, 20, 21),
       tags: ["possum"],

--- a/integration-tests/cypress/integration/api/recordings/visit_tags.ts
+++ b/integration-tests/cypress/integration/api/recordings/visit_tags.ts
@@ -99,7 +99,7 @@ describe("Visits : tracks and tags", () => {
   it("User tags conflict", () => {
     const camera = "conflicter";
     cy.apiCreateUser(Gee);
-    cy.apiAddUserToGroup(Dee, Gee, group, true);
+    cy.apiGroupUserAdd(Dee, Gee, group, true);
     cy.apiCreateDevice(camera, group);
     const recording = cy.uploadRecording(camera, {
       time: new Date(2021, 1, 20, 21),

--- a/integration-tests/cypress/integration/api/recordings/visit_tags.ts
+++ b/integration-tests/cypress/integration/api/recordings/visit_tags.ts
@@ -15,14 +15,14 @@ describe("Visits : tracks and tags", () => {
     const notracks = [];
     const noVisits = [];
     cy.apiDeviceAdd(camera, group);
-    cy.testRecordingAddWithTestData(camera, { tracks: notracks });
+    cy.testUploadRecording(camera, { tracks: notracks });
     cy.checkVisits(Dee, camera, noVisits);
   });
 
   it("all automatic tags other than master are ignored - to prevent wallaby ai being used on other projects", () => {
     const camera = "only_master";
     cy.apiDeviceAdd(camera, group);
-    cy.testRecordingAddWithTestData(camera, {
+    cy.testUploadRecording(camera, {
       model: "different",
       tags: ["cat"],
     });
@@ -32,27 +32,27 @@ describe("Visits : tracks and tags", () => {
   it("each recording contributes a vote for what the animal is", () => {
     const camera = "multiple_tracks";
     cy.apiDeviceAdd(camera, group);
-    cy.testRecordingAddWithTestData(camera, { tags: ["possum", "rat"] });
-    cy.testRecordingAddWithTestData(camera, { tags: ["cat"] });
-    cy.testRecordingAddWithTestData(camera, { tags: ["cat"] });
+    cy.testUploadRecording(camera, { tags: ["possum", "rat"] });
+    cy.testUploadRecording(camera, { tags: ["cat"] });
+    cy.testUploadRecording(camera, { tags: ["cat"] });
     cy.checkVisitTags(Dee, camera, ["cat"]);
   });
 
   it("each track in a recording gets contributes a vote for what the animal is", () => {
     const camera = "multiple_tracks2";
     cy.apiDeviceAdd(camera, group);
-    cy.testRecordingAddWithTestData(camera, {
+    cy.testUploadRecording(camera, {
       tags: ["possum", "rat", "rat", "rat"],
     });
-    cy.testRecordingAddWithTestData(camera, { tags: ["cat"] });
-    cy.testRecordingAddWithTestData(camera, { tags: ["cat"] });
+    cy.testUploadRecording(camera, { tags: ["cat"] });
+    cy.testUploadRecording(camera, { tags: ["cat"] });
     cy.checkVisitTags(Dee, camera, ["rat"]);
   });
 
   it("track tag 'unidentified` is ignored when deciding label to use", () => {
     const camera = "has_unidentified";
     cy.apiDeviceAdd(camera, group);
-    cy.testRecordingAddWithTestData(camera, {
+    cy.testUploadRecording(camera, {
       tags: ["possum", "unidentified", "unidentified", "unidentified"],
     });
     cy.checkVisitTags(Dee, camera, ["possum"]);
@@ -61,7 +61,7 @@ describe("Visits : tracks and tags", () => {
   it("What happens when user tags as 'unidentified`?", () => {
     const camera = "user_unidentified_tracks";
     cy.apiDeviceAdd(camera, group);
-    cy.testRecordingAddWithTestData(camera, { tags: ["possum"] }).thenUserTagAs(
+    cy.testUploadRecording(camera, { tags: ["possum"] }).thenUserTagAs(
       Dee,
       "unidentified"
     );
@@ -71,7 +71,7 @@ describe("Visits : tracks and tags", () => {
   it("if a user tags a track then this is what should be used as the track tag", () => {
     const camera = "userTagged";
     cy.apiDeviceAdd(camera, group);
-    cy.testRecordingAddWithTestData(camera, {
+    cy.testUploadRecording(camera, {
       tracks: [{ tag: "cat" }],
     }).thenUserTagAs(Dee, "rabbit");
     cy.checkVisitTags(Dee, camera, ["rabbit"]);
@@ -80,18 +80,18 @@ describe("Visits : tracks and tags", () => {
   it("User tag is preferred over AI tag", () => {
     const camera = "userVsMultiple";
     cy.apiDeviceAdd(camera, group);
-    cy.testRecordingAddWithTestData(camera, {
+    cy.testUploadRecording(camera, {
       time: new Date(2021, 1, 20, 21),
       tags: ["possum", "rat", "rat"],
     }).thenUserTagAs(Dee, "rabbit");
-    cy.testRecordingAddWithTestData(camera, { tags: ["possum"] });
+    cy.testUploadRecording(camera, { tags: ["possum"] });
     cy.checkVisitTags(Dee, camera, ["rabbit"]);
   });
 
   it("User animal tag is preferred over user unknown tag", () => {
     const camera = "userAnimalUnknown";
     cy.apiDeviceAdd(camera, group);
-    cy.testRecordingAddWithTestData(camera, {
+    cy.testUploadRecording(camera, {
       tags: ["unidentified", "unidentified", "unidentified"],
     }).then((recID: number) => {
       cy.testUserTagRecording(recID, 0, Dee, "possum");
@@ -105,7 +105,7 @@ describe("Visits : tracks and tags", () => {
     cy.apiUserAdd(Gee);
     cy.apiGroupUserAdd(Dee, Gee, group, true);
     cy.apiDeviceAdd(camera, group);
-    const recording = cy.testRecordingAddWithTestData(camera, {
+    const recording = cy.testUploadRecording(camera, {
       time: new Date(2021, 1, 20, 21),
       tags: ["possum"],
     });

--- a/integration-tests/cypress/integration/api/recordings/visit_times.ts
+++ b/integration-tests/cypress/integration/api/recordings/visit_times.ts
@@ -13,17 +13,17 @@ describe("Visits : times and recording groupings", () => {
   it("recordings less than 10mins apart are considered a single visit", () => {
     const camera = "closeRecordings";
     cy.apiDeviceAdd(camera, group);
-    cy.uploadRecording(camera, {});
-    cy.uploadRecording(camera, { minsLater: 9 });
-    cy.uploadRecording(camera, { minsLater: 9 });
+    cy.testRecordingAddWithTestData(camera, {});
+    cy.testRecordingAddWithTestData(camera, { minsLater: 9 });
+    cy.testRecordingAddWithTestData(camera, { minsLater: 9 });
     cy.checkVisits(Dee, camera, [{ recordings: 3 }]);
   });
 
   it("recordings more 10mins apart are different visits", () => {
     const camera = "apartRecordings";
     cy.apiDeviceAdd(camera, group);
-    cy.uploadRecording(camera, {});
-    cy.uploadRecording(camera, { minsLater: 11 });
+    cy.testRecordingAddWithTestData(camera, {});
+    cy.testRecordingAddWithTestData(camera, { minsLater: 11 });
     cy.checkVisits(Dee, camera, [{ recordings: 1 }, { recordings: 1 }]);
   });
 
@@ -31,7 +31,7 @@ describe("Visits : times and recording groupings", () => {
     const camera = "dateTimes";
     const videoStart = new Date(2021, 1, 20, 21);
     cy.apiDeviceAdd(camera, group);
-    cy.uploadRecording(camera, {
+    cy.testRecordingAddWithTestData(camera, {
       time: videoStart,
       tracks: [
         {
@@ -49,7 +49,7 @@ describe("Visits : times and recording groupings", () => {
     const camera = "dateTimes2";
     const videoStart = new Date(2021, 1, 20, 21);
     cy.apiDeviceAdd(camera, group);
-    cy.uploadRecording(camera, {
+    cy.testRecordingAddWithTestData(camera, {
       time: videoStart,
       tracks: [
         {
@@ -71,7 +71,7 @@ describe("Visits : times and recording groupings", () => {
     const camera = "dateTimes3";
     const videoStart = new Date(2021, 1, 20, 21);
     cy.apiDeviceAdd(camera, group);
-    cy.uploadRecording(camera, {
+    cy.testRecordingAddWithTestData(camera, {
       time: videoStart,
       tracks: [
         {
@@ -80,7 +80,7 @@ describe("Visits : times and recording groupings", () => {
         },
       ],
     });
-    cy.uploadRecording(camera, {
+    cy.testRecordingAddWithTestData(camera, {
       secsLater: 66,
       tracks: [
         {

--- a/integration-tests/cypress/integration/api/recordings/visit_times.ts
+++ b/integration-tests/cypress/integration/api/recordings/visit_times.ts
@@ -7,12 +7,12 @@ describe("Visits : times and recording groupings", () => {
   const group = "VisitTests";
 
   before(() => {
-    cy.apiCreateUserGroup(Dee, group);
+    cy.testCreateUserAndGroup(Dee, group);
   });
 
   it("recordings less than 10mins apart are considered a single visit", () => {
     const camera = "closeRecordings";
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     cy.uploadRecording(camera, {});
     cy.uploadRecording(camera, { minsLater: 9 });
     cy.uploadRecording(camera, { minsLater: 9 });
@@ -21,7 +21,7 @@ describe("Visits : times and recording groupings", () => {
 
   it("recordings more 10mins apart are different visits", () => {
     const camera = "apartRecordings";
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     cy.uploadRecording(camera, {});
     cy.uploadRecording(camera, { minsLater: 11 });
     cy.checkVisits(Dee, camera, [{ recordings: 1 }, { recordings: 1 }]);
@@ -30,7 +30,7 @@ describe("Visits : times and recording groupings", () => {
   it("test start and end date of visits", () => {
     const camera = "dateTimes";
     const videoStart = new Date(2021, 1, 20, 21);
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     cy.uploadRecording(camera, {
       time: videoStart,
       tracks: [
@@ -48,7 +48,7 @@ describe("Visits : times and recording groupings", () => {
   it("test start and end date of visits with first track finishing later than second", () => {
     const camera = "dateTimes2";
     const videoStart = new Date(2021, 1, 20, 21);
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     cy.uploadRecording(camera, {
       time: videoStart,
       tracks: [
@@ -70,7 +70,7 @@ describe("Visits : times and recording groupings", () => {
   it("test start and end date of visits with multiple videos", () => {
     const camera = "dateTimes3";
     const videoStart = new Date(2021, 1, 20, 21);
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     cy.uploadRecording(camera, {
       time: videoStart,
       tracks: [

--- a/integration-tests/cypress/integration/api/recordings/visit_times.ts
+++ b/integration-tests/cypress/integration/api/recordings/visit_times.ts
@@ -13,17 +13,17 @@ describe("Visits : times and recording groupings", () => {
   it("recordings less than 10mins apart are considered a single visit", () => {
     const camera = "closeRecordings";
     cy.apiDeviceAdd(camera, group);
-    cy.testRecordingAddWithTestData(camera, {});
-    cy.testRecordingAddWithTestData(camera, { minsLater: 9 });
-    cy.testRecordingAddWithTestData(camera, { minsLater: 9 });
+    cy.testUploadRecording(camera, {});
+    cy.testUploadRecording(camera, { minsLater: 9 });
+    cy.testUploadRecording(camera, { minsLater: 9 });
     cy.checkVisits(Dee, camera, [{ recordings: 3 }]);
   });
 
   it("recordings more 10mins apart are different visits", () => {
     const camera = "apartRecordings";
     cy.apiDeviceAdd(camera, group);
-    cy.testRecordingAddWithTestData(camera, {});
-    cy.testRecordingAddWithTestData(camera, { minsLater: 11 });
+    cy.testUploadRecording(camera, {});
+    cy.testUploadRecording(camera, { minsLater: 11 });
     cy.checkVisits(Dee, camera, [{ recordings: 1 }, { recordings: 1 }]);
   });
 
@@ -31,7 +31,7 @@ describe("Visits : times and recording groupings", () => {
     const camera = "dateTimes";
     const videoStart = new Date(2021, 1, 20, 21);
     cy.apiDeviceAdd(camera, group);
-    cy.testRecordingAddWithTestData(camera, {
+    cy.testUploadRecording(camera, {
       time: videoStart,
       tracks: [
         {
@@ -49,7 +49,7 @@ describe("Visits : times and recording groupings", () => {
     const camera = "dateTimes2";
     const videoStart = new Date(2021, 1, 20, 21);
     cy.apiDeviceAdd(camera, group);
-    cy.testRecordingAddWithTestData(camera, {
+    cy.testUploadRecording(camera, {
       time: videoStart,
       tracks: [
         {
@@ -71,7 +71,7 @@ describe("Visits : times and recording groupings", () => {
     const camera = "dateTimes3";
     const videoStart = new Date(2021, 1, 20, 21);
     cy.apiDeviceAdd(camera, group);
-    cy.testRecordingAddWithTestData(camera, {
+    cy.testUploadRecording(camera, {
       time: videoStart,
       tracks: [
         {
@@ -80,7 +80,7 @@ describe("Visits : times and recording groupings", () => {
         },
       ],
     });
-    cy.testRecordingAddWithTestData(camera, {
+    cy.testUploadRecording(camera, {
       secsLater: 66,
       tracks: [
         {

--- a/integration-tests/cypress/performance/monitoring_performance.ts
+++ b/integration-tests/cypress/performance/monitoring_performance.ts
@@ -6,14 +6,14 @@ describe("Monitoring : times and recording groupings", () => {
   const max_page_length = 100;
 
   before(() => {
-    cy.apiCreateUserGroup(Dexter, group);
+    cy.testCreateUserAndGroup(Dexter, group);
   });
 
   it("can handle maximum number of visits per page", () => {
     const camera = "visits-per-page";
     const visits = [];
     // add 1000 recordings
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     cy.uploadRecording(camera, { time: "20:55", duration: 10 });
     for (let i = 0; i < max_page_length * 10 - 1; i++) {
       cy.uploadRecording(camera, { minsLater: 11 });
@@ -45,7 +45,7 @@ describe("Monitoring : times and recording groupings", () => {
     const camera = "default_page_size";
     const visits = [];
     // add 1 page plus 1 worth of recordings
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     cy.uploadRecording(camera, { time: "20:55", duration: 10 });
     for (let i = 0; i < max_page_length; i++) {
       cy.uploadRecording(camera, { minsLater: 11 });
@@ -69,7 +69,7 @@ describe("Monitoring : times and recording groupings", () => {
   it("can handle large number of recordings per visit", () => {
     const camera = "recordings-per-visit";
     // add 1000 recordings
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     cy.uploadRecording(camera, { time: "20:55", duration: 10 });
     for (let i = 0; i < 999; i++) {
       cy.uploadRecording(camera, { minsLater: 9 });
@@ -88,7 +88,7 @@ describe("Monitoring : times and recording groupings", () => {
     const camera = "pages";
 
     // add 1000 recordings
-    cy.apiCreateDevice(camera, group);
+    cy.apiDeviceAdd(camera, group);
     cy.uploadRecording(camera, { time: "20:55", duration: 10 });
     for (let i = 0; i < 999; i++) {
       cy.uploadRecording(camera, { minsLater: 11 });

--- a/integration-tests/cypress/performance/monitoring_performance.ts
+++ b/integration-tests/cypress/performance/monitoring_performance.ts
@@ -14,9 +14,9 @@ describe("Monitoring : times and recording groupings", () => {
     const visits = [];
     // add 1000 recordings
     cy.apiDeviceAdd(camera, group);
-    cy.uploadRecording(camera, { time: "20:55", duration: 10 });
+    cy.apiRecordingAdd(camera, { time: "20:55", duration: 10 });
     for (let i = 0; i < max_page_length * 10 - 1; i++) {
-      cy.uploadRecording(camera, { minsLater: 11 });
+      cy.apiRecordingAdd(camera, { minsLater: 11 });
     }
 
     for (let i = 0; i < max_page_length; i++) {
@@ -46,9 +46,9 @@ describe("Monitoring : times and recording groupings", () => {
     const visits = [];
     // add 1 page plus 1 worth of recordings
     cy.apiDeviceAdd(camera, group);
-    cy.uploadRecording(camera, { time: "20:55", duration: 10 });
+    cy.apiRecordingAdd(camera, { time: "20:55", duration: 10 });
     for (let i = 0; i < max_page_length; i++) {
-      cy.uploadRecording(camera, { minsLater: 11 });
+      cy.apiRecordingAdd(camera, { minsLater: 11 });
     }
 
     // expected visits on 1st page is array of max_page_length of visits
@@ -70,9 +70,9 @@ describe("Monitoring : times and recording groupings", () => {
     const camera = "recordings-per-visit";
     // add 1000 recordings
     cy.apiDeviceAdd(camera, group);
-    cy.uploadRecording(camera, { time: "20:55", duration: 10 });
+    cy.apiRecordingAdd(camera, { time: "20:55", duration: 10 });
     for (let i = 0; i < 999; i++) {
-      cy.uploadRecording(camera, { minsLater: 9 });
+      cy.apiRecordingAdd(camera, { minsLater: 9 });
     }
 
     const visits = [{ recordings: 1000 }];
@@ -89,9 +89,9 @@ describe("Monitoring : times and recording groupings", () => {
 
     // add 1000 recordings
     cy.apiDeviceAdd(camera, group);
-    cy.uploadRecording(camera, { time: "20:55", duration: 10 });
+    cy.apiRecordingAdd(camera, { time: "20:55", duration: 10 });
     for (let i = 0; i < 999; i++) {
-      cy.uploadRecording(camera, { minsLater: 11 });
+      cy.apiRecordingAdd(camera, { minsLater: 11 });
     }
 
     const visits = [{ recordings: 1 }];


### PR DESCRIPTION
Four changes:
- Add tests for /api/V1/groups
- Update & correct apidoc documentation for /api/V1/groups
- Apply consistent function naming across all cypress test API wrappers:
      single API wrappers:  api<endpointName><Action>
      test functions not mapped to single APIs: test<Action>
- Re-order types.d.ts file by database table (to group types by the object type they describe) and add comments detailing the source endpoint of the type definition in API