### PR TITLE
Connect to influx though port 443 to avoid firewall on default port

### DIFF
--- a/api/scripts/influx-metrics.ts
+++ b/api/scripts/influx-metrics.ts
@@ -135,6 +135,8 @@ async function influxConnect() {
     database: Config.influx.database,
     username: Config.influx.username,
     password: Config.influx.password,
+    protocol: 'https',
+    port: 443,
     schema: [
       {
         measurement: stateCountMeasurement,


### PR DESCRIPTION
Was not able to report to influx as there was a firewall blocking the default port for influx.