### PR TITLE
fix(Device): visits to recordings path on device link

### DIFF
--- a/browse/src/components/Groups/DevicesTab.vue
+++ b/browse/src/components/Groups/DevicesTab.vue
@@ -60,7 +60,7 @@
           :group-name="groupName"
           :device-name="row.item.deviceName"
           :type="row.item.type"
-          :context="row.item.type === 'thermal' ? 'visits' : 'recordings'"
+          context="recordings"
         />
       </template>
       <template v-slot:cell(deviceHealth)="row">


### PR DESCRIPTION
Issue with devices page not navigating out of visits to recordings for thermal devices. Only happened on mobile as desktop would navigate to recordings of the device.

Fix is just making the link go straight to recordings instead of visits which I presume are now only associated to stations anyways.

Currently on test, and seems to work.