### PR TITLE
fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,5 @@ EXPOSE 5432
 
 COPY docker-entrypoint.sh /
 
-COPY api ./api
-
-COPY types ./types
-
-RUN cd api && npm install
 
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -52,6 +52,12 @@ sudo -i -u postgres psql cacophonytest -f /app/api/db-seed.sql
 
 echo "alias psqltest='sudo -i -u postgres psql cacophonytest'" > ~/.bashrc
 
+
+echo "---- install npm packages ----"
+
+npm install
+cd ../types && npm install
+cd ../api
 echo "---- update npm packages ----"
 npm i
 


### PR DESCRIPTION
api and types are already mounted in docker-compose.yml so no need to copy directory
packages need to be installed in entry point other wise there is no tsc or packages etc