### PR TITLE
Monitoring Stats

### DIFF
--- a/api/api/V1/Recording.ts
+++ b/api/api/V1/Recording.ts
@@ -1198,7 +1198,6 @@ export default (app: Application, baseUrl: string) => {
       csv.writeToStream(response, rows);
     }
   );
-  
 
   /**
    * @api {get} /api/v1/recordings/:id Get a recording
@@ -1280,7 +1279,6 @@ export default (app: Application, baseUrl: string) => {
       }
     }
   );
-
 
   /**
    * @api {get} /api/v1/recordings/track-tags/count Get track tag counts

--- a/api/api/V1/User.ts
+++ b/api/api/V1/User.ts
@@ -113,7 +113,7 @@ export default function (app: Application, baseUrl: string) {
     async (request, response) => {
       const users = await models.User.getAll(
         {},
-        response.locals.viewAsSuperUser
+        response.locals.requestUser.hasGlobalWrite()
       );
 
       return successResponse(response, { usersList: mapUsers(users, true) });

--- a/api/api/V1/recordingUtil.ts
+++ b/api/api/V1/recordingUtil.ts
@@ -27,7 +27,7 @@ import config from "@config";
 import type { Recording, RecordingQueryOptions } from "@models/Recording.js";
 import type { Event, QueryOptions } from "@models/Event.js";
 import type { User } from "@models/User.js";
-import Sequelize, { Op } from "sequelize";
+import Sequelize, { Op, QueryTypes } from "sequelize";
 import type { DeviceVisitMap, VisitEvent, VisitSummary } from "./Visits.js";
 import { DeviceSummary, Visit } from "./Visits.js";
 import type { Station } from "@models/Station.js";
@@ -978,6 +978,123 @@ export async function getTrackTags(
     // TODO - The exact AI model you will need data attribute from track tag
     labeller: row.UserId ? `id_${row.UserId.toString()}` : "AI",
   }));
+}
+interface TrackTagsCountOptions {
+  models: ModelsDictionary;
+  userId: string;
+  viewAsSuperUser: boolean;
+  includeAI: boolean;
+  recordingType: RecordingType;
+  exclude: number;
+  offset: number;
+  limit: number;
+  groupId?: number;
+}
+
+function buildTrackTagCountSQL(options: TrackTagsCountOptions): string {
+  const { viewAsSuperUser, includeAI, groupId } = options;
+
+  // Array to hold different parts of the SQL query
+  const sqlParts: string[] = [];
+
+  // Basic SQL structure
+  sqlParts.push(`
+  WITH FilteredTags AS (
+    SELECT
+      TT."what",
+      TT."UserId",
+      U."userName",
+      R."type",
+      G."id" AS "groupId",
+      G."groupName",
+      S."id" AS "stationId",
+      S."name" AS "stationName",
+      D."id" AS "deviceId",
+      D."deviceName"
+    FROM "TrackTags" TT
+    INNER JOIN "Users" U ON TT."UserId" = U."id"
+    INNER JOIN "Tracks" T ON TT."TrackId" = T."id"
+    INNER JOIN "Recordings" R ON T."RecordingId" = R."id"
+    INNER JOIN "Groups" G ON R."GroupId" = G."id"
+    INNER JOIN "Devices" D ON R."DeviceId" = D."id"
+    INNER JOIN "Stations" S ON R."StationId" = S."id"
+  `);
+
+  // Adding condition for user group check if not a super user
+  if (!viewAsSuperUser) {
+    sqlParts.push(
+      `INNER JOIN "GroupUsers" GU ON G."id" = GU."GroupId" AND GU."UserId" = :userId`
+    );
+  }
+
+  // Adding WHERE clause and initial conditions
+  sqlParts.push(`
+    WHERE R."type" = :recordingType
+    AND TT."what" NOT IN (:exclude)
+  `);
+
+  if (!includeAI) {
+    sqlParts.push(`AND TT."UserId" IS NOT NULL`);
+  }
+
+  if (groupId) {
+    sqlParts.push(`AND G."id" = :groupId`);
+  }
+
+  // Completing the CTE and starting the main query
+  sqlParts.push(`
+  )
+  SELECT
+    "what",
+    "UserId",
+    "userName",
+    COUNT("what") AS "trackTagCount",
+    "groupId",
+    "groupName",
+    "stationId",
+    "stationName",
+    "deviceId",
+    "deviceName"
+  FROM FilteredTags
+  GROUP BY
+    "what",
+    "UserId",
+    "userName",
+    "groupId",
+    "groupName",
+    "stationId",
+    "stationName",
+    "deviceId",
+    "deviceName"
+  `);
+
+  if (options.limit) {
+    sqlParts.push(`LIMIT :limit`);
+  }
+
+  if (options.offset) {
+    sqlParts.push(`OFFSET :offset`);
+  }
+
+  // Join all parts to form the final SQL query
+  return sqlParts.join(" ");
+}
+
+export async function getTrackTagsCount(options: TrackTagsCountOptions) {
+  const sql = buildTrackTagCountSQL(options);
+  const replacements = {
+    recordingType: options.recordingType,
+    exclude: options.exclude,
+    limit: options.limit,
+    offset: options.offset,
+    userId: options.userId,
+    groupId: options.groupId,
+  };
+  const result = await options.models.sequelize.query(sql, {
+    replacements,
+    type: QueryTypes.SELECT,
+  });
+  return result;
 }
 
 // Returns a promise for report rows for a set of recordings. Takes

--- a/api/migrations/20231003022041-recordings-deleteAt-duration-index.cjs
+++ b/api/migrations/20231003022041-recordings-deleteAt-duration-index.cjs
@@ -1,0 +1,43 @@
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    /**
+     * Add altering commands here.
+     *
+     * Example:
+     * await queryInterface.createTable('users', { id: Sequelize.INTEGER });
+     */
+
+    await queryInterface.addIndex("Recordings", ["deletedAt", "duration"], {
+      name: "idx_recordings_deletedat_duration",
+    });
+
+    await queryInterface.addIndex("TrackTags", ["archivedAt"], {
+      name: "idx_tracktags_archivedat",
+    });
+
+    await queryInterface.addIndex("Tracks", ["archivedAt"], {
+      name: "idx_tracks_archivedat",
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    /**
+     * Add reverting commands here.
+     *
+     * Example:
+     * await queryInterface.dropTable('users');
+     */
+
+    await queryInterface.removeIndex(
+      "Recordings",
+      "idx_recordings_deletedat_duration"
+    );
+
+    await queryInterface.removeIndex("TrackTags", "idx_tracktags_archivedat");
+
+    await queryInterface.removeIndex("Tracks", "idx_tracks_archivedat");
+  },
+};

--- a/api/models/User.ts
+++ b/api/models/User.ts
@@ -165,7 +165,7 @@ export default function (
   User.getAll = async function (where, isSuperAdmin: boolean) {
     return this.findAll({
       where,
-      attributes: [...this.publicFields, ...(isSuperAdmin && ["email"])],
+      attributes: [...this.publicFields, ...(isSuperAdmin ? ["email"] : [])],
     });
   };
 

--- a/browse/package-lock.json
+++ b/browse/package-lock.json
@@ -51,6 +51,7 @@
         "@types/chart.js": "^2.9.28",
         "@types/colormap": "^2.3.1",
         "@types/leaflet": "^1.5.7",
+        "@types/lodash": "^4.14.199",
         "@types/suncalc": "^1.8.0",
         "@types/vuelidate": "^0.7.15",
         "@types/wavesurfer.js": "^5.2.2",
@@ -1917,6 +1918,12 @@
       "dependencies": {
         "@types/geojson": "*"
       }
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.199",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.199.tgz",
+      "integrity": "sha512-Vrjz5N5Ia4SEzWWgIVwnHNEnb1UE1XMkvY5DGXrAeOGE9imk0hgTHh5GyDjLDJi9OTCn9oo9dXH1uToK1VRfrg==",
+      "dev": true
     },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
@@ -14820,6 +14827,12 @@
       "requires": {
         "@types/geojson": "*"
       }
+    },
+    "@types/lodash": {
+      "version": "4.14.199",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.199.tgz",
+      "integrity": "sha512-Vrjz5N5Ia4SEzWWgIVwnHNEnb1UE1XMkvY5DGXrAeOGE9imk0hgTHh5GyDjLDJi9OTCn9oo9dXH1uToK1VRfrg==",
+      "dev": true
     },
     "@types/minimatch": {
       "version": "3.0.5",

--- a/browse/package.json
+++ b/browse/package.json
@@ -59,6 +59,7 @@
     "@types/chart.js": "^2.9.28",
     "@types/colormap": "^2.3.1",
     "@types/leaflet": "^1.5.7",
+    "@types/lodash": "^4.14.199",
     "@types/suncalc": "^1.8.0",
     "@types/vuelidate": "^0.7.15",
     "@types/wavesurfer.js": "^5.2.2",

--- a/browse/src/api/Recording.api.ts
+++ b/browse/src/api/Recording.api.ts
@@ -228,9 +228,22 @@ function queryTrackTags(
   );
 }
 
+export type TrackTagCount = {
+  what: string;
+  UserId: number;
+  userName: string;
+  trackTagCount: string;
+  groupId: number;
+  groupName: string;
+  stationId: number;
+  stationName: string;
+  deviceId: number;
+  deviceName: string;
+};
+
 function queryTrackTagsCount(
   params: TrackTagQuery
-): Promise<FetchResult<QueryResult<any>>> {
+): Promise<FetchResult<QueryResult<TrackTagCount>>> {
   if (!shouldViewAsSuperUser()) {
     params["view-mode"] = "user";
   }

--- a/browse/src/api/Station.api.ts
+++ b/browse/src/api/Station.api.ts
@@ -87,6 +87,12 @@ function getStationRecordingsCount(
   return CacophonyApi.get(`/api/v1/stations/${stationId}/recordings-count`);
 }
 
+function getStationsRecordingsCount(
+  stationIds: StationId[]
+): Promise<FetchResult<{ counts: { stationId: number; count: number }[] }>> {
+  return CacophonyApi.post(`/api/v1/stations/recordings-count`, { stationIds });
+}
+
 function getStationCacophonyIndexBulk(
   id: StationId,
   from: String,
@@ -177,6 +183,7 @@ export default {
   getReferenceImage,
   deleteReferenceImage,
   getStationRecordingsCount,
+  getStationsRecordingsCount,
   getStationCacophonyIndex,
   getStationCacophonyIndexBulk,
   getStationSpeciesCount,

--- a/browse/src/components/Audio/AudioPlayer.vue
+++ b/browse/src/components/Audio/AudioPlayer.vue
@@ -369,23 +369,6 @@ export default defineComponent({
       element.style.transform = `scaleX(${x}) scaleY(${y})`;
       element.style.transformOrigin = `${origin}px bottom`;
     };
-    const applyScaleToElements = (
-      svgElement: SVGElement,
-      origin: number,
-      xScale: number,
-      yScale: number
-    ) => {
-      // Select both rect and circle elements
-      const elements = svgElement.querySelectorAll<SVGElement>("rect, circle");
-
-      elements.forEach((element) => {
-        // Apply scale
-        element.style.transform = `scale(${xScale}, ${yScale})`;
-
-        // Apply transform origin
-        element.style.transformOrigin = `${origin}px bottom`;
-      });
-    };
 
     const updateZoom = () => {
       if (!overlay.value) {
@@ -409,7 +392,7 @@ export default defineComponent({
       const scale = zoomed.value.enabled ? zoomed.value.scale : 1;
       const xScale = parseFloat(scale.toFixed(1));
       const yScale = props.sampleRate / newSampleRate.value;
-      applyScaleToElements(overlay.value, origin, xScale, yScale);
+      applyScale(overlay.value, origin, xScale, yScale);
       applyScale(spectrogram.value, origin, xScale, yScale);
       // Apply zoom to zoom indicators
       const translateY = "translateY(-3px)";
@@ -476,7 +459,6 @@ export default defineComponent({
             opacity: "60%",
             fill: "none",
             cursor: "pointer",
-            "vector-effect": "non-scaling-stroke",
           },
         },
         "rect"
@@ -575,7 +557,6 @@ export default defineComponent({
               opacity: "60%",
               cursor: "pointer",
               fill: "none",
-              "vector-effect": "non-scaling-stroke",
             },
           },
           "rect"
@@ -920,7 +901,6 @@ export default defineComponent({
       }
       createRectFromTrack(track);
       attachControls(track.id);
-      updateZoom();
     };
 
     // Watch for changes to the selected track and update the spectrogram

--- a/browse/src/components/Audio/AudioPlayer.vue
+++ b/browse/src/components/Audio/AudioPlayer.vue
@@ -369,6 +369,23 @@ export default defineComponent({
       element.style.transform = `scaleX(${x}) scaleY(${y})`;
       element.style.transformOrigin = `${origin}px bottom`;
     };
+    const applyScaleToElements = (
+      svgElement: SVGElement,
+      origin: number,
+      xScale: number,
+      yScale: number
+    ) => {
+      // Select both rect and circle elements
+      const elements = svgElement.querySelectorAll<SVGElement>("rect, circle");
+
+      elements.forEach((element) => {
+        // Apply scale
+        element.style.transform = `scale(${xScale}, ${yScale})`;
+
+        // Apply transform origin
+        element.style.transformOrigin = `${origin}px bottom`;
+      });
+    };
 
     const updateZoom = () => {
       if (!overlay.value) {
@@ -392,7 +409,7 @@ export default defineComponent({
       const scale = zoomed.value.enabled ? zoomed.value.scale : 1;
       const xScale = parseFloat(scale.toFixed(1));
       const yScale = props.sampleRate / newSampleRate.value;
-      applyScale(overlay.value, origin, xScale, yScale);
+      applyScaleToElements(overlay.value, origin, xScale, yScale);
       applyScale(spectrogram.value, origin, xScale, yScale);
       // Apply zoom to zoom indicators
       const translateY = "translateY(-3px)";
@@ -459,6 +476,7 @@ export default defineComponent({
             opacity: "60%",
             fill: "none",
             cursor: "pointer",
+            "vector-effect": "non-scaling-stroke",
           },
         },
         "rect"
@@ -557,6 +575,7 @@ export default defineComponent({
               opacity: "60%",
               cursor: "pointer",
               fill: "none",
+              "vector-effect": "non-scaling-stroke",
             },
           },
           "rect"
@@ -901,6 +920,7 @@ export default defineComponent({
       }
       createRectFromTrack(track);
       attachControls(track.id);
+      updateZoom();
     };
 
     // Watch for changes to the selected track and update the spectrogram

--- a/browse/src/components/NavBar.vue
+++ b/browse/src/components/NavBar.vue
@@ -29,8 +29,8 @@
 
       <b-collapse id="navbarToggler" is-nav>
         <b-navbar-nav>
-          <b-nav-item to="/analysis">Analysis</b-nav-item>
           <b-nav-item to="/recordings">Recordings</b-nav-item>
+          <b-nav-item to="/monitoring-analysis">Stats</b-nav-item>
         </b-navbar-nav>
 
         <b-navbar-nav class="ml-auto align-items-center">
@@ -51,7 +51,7 @@
           >
             <template slot="button-content">
               <font-awesome-icon
-                v-if="hasGlobalReadPermissions"
+                v-if="isSuperUser"
                 :icon="['fas', 'user-secret']"
                 class="icon"
               />
@@ -60,12 +60,12 @@
                 :icon="['far', 'user-circle']"
                 class="icon"
               />&nbsp;{{ userName }}
-              <span v-if="hasGlobalReadPermissions && !isViewingAsOtherUser()">
+              <span v-if="isSuperUser && !isViewingAsOtherUser()">
                 {{ isViewingAsSuperUser ? "(super admin)" : "(user)" }}
               </span>
             </template>
 
-            <b-dropdown-group header="View as" v-if="hasGlobalReadPermissions">
+            <b-dropdown-group header="View as" v-if="isSuperUser">
               <b-dropdown-item
                 :active="isViewingAsSuperUser"
                 @click="viewAsSuperUser"
@@ -227,11 +227,6 @@ export default {
     isSuperUser() {
       return this.globalPermission === "write";
     },
-    hasGlobalReadPermissions() {
-      return (
-        this.globalPermission === "write" || this.globalPermission === "read"
-      );
-    },
     showChangeUserViewDialog: {
       async set(val) {
         this.internalShowChangeUserViewDialog = val;
@@ -280,12 +275,12 @@ export default {
       window.localStorage.setItem("dismissed-browse-next-message", "true");
     },
     async initUsersList() {
-      if (this.hasGlobalReadPermissions) {
+      if (this.isSuperUser) {
         const response = await User.list();
         if (response.success) {
           this.users = response.result.usersList
             .map(({ userName, id, email }) => ({
-              name: `${userName} ${email && `<${email}>`}`,
+              name: `${userName} ${email ? `<${email}>` : ""}`,
               email,
               id,
             }))

--- a/browse/src/components/QueryRecordings/SelectDevice.vue
+++ b/browse/src/components/QueryRecordings/SelectDevice.vue
@@ -153,6 +153,10 @@ export default defineComponent({
       type: Array as PropType<string[]>,
       default: () => [] as string[],
     },
+    lazy: {
+      type: Boolean,
+      default: true,
+    },
   },
   data() {
     return {
@@ -383,9 +387,10 @@ export default defineComponent({
     if (
       this.selectedStations.length ||
       this.selectedDevices.length ||
-      this.selectedGroups.length
+      this.selectedGroups.length ||
+      !this.lazy
     ) {
-      await this.loadValues(true);
+      await this.loadValues(this.lazy);
     }
   },
 });

--- a/browse/src/components/TabListItem.vue
+++ b/browse/src/components/TabListItem.vue
@@ -1,5 +1,10 @@
 <template>
-  <b-tab :title="title" :lazy="lazy" v-if="showTabs">
+  <b-tab
+    :title-item-class="showTab"
+    :title="title"
+    :lazy="lazy"
+    v-if="showTabs"
+  >
     <template #title>
       <slot name="title"></slot>
     </template>
@@ -45,11 +50,21 @@ export default {
       type: Boolean,
       default: true,
     },
+    show: {
+      type: Boolean,
+      default: true,
+    },
   },
   methods: {
     select() {
       this.$parent.$emit("selected");
       this.$parent.$emit("input", this.index);
+    },
+  },
+
+  computed: {
+    showTab() {
+      return this.show ? "" : "d-none";
     },
   },
 };

--- a/browse/src/components/Video/AudioRecording.vue
+++ b/browse/src/components/Video/AudioRecording.vue
@@ -505,7 +505,7 @@ export default defineComponent({
     const filterHuman = ref(false);
 
     const getDisplayTags = (track: ApiTrackResponse): DisplayTag[] => {
-      const automaticTag = track.tags.find(
+      const automaticTags = track.tags.filter(
         (tag) => tag.automatic && tag.data.name === "Master"
       );
       const humanTags = track.tags.filter((tag) => !tag.automatic);
@@ -521,10 +521,10 @@ export default defineComponent({
                 return { ...humanTags[0], what: "Multiple" };
               }
             });
-      if (automaticTag) {
+      if (automaticTags) {
         if (humanTags.length > 0) {
-          const confirmedTag = humanTags.find(
-            (tag) => automaticTag.what === tag.what
+          const confirmedTag = humanTags.find((tag) =>
+            automaticTags.find((autoTag) => autoTag.what === tag.what)
           );
           if (confirmedTag) {
             return [
@@ -540,19 +540,17 @@ export default defineComponent({
                 ...humanTag,
                 class: TagClass.Human,
               },
-              {
+              ...automaticTags.map((automaticTag) => ({
                 ...automaticTag,
                 class: TagClass.Denied,
-              },
+              })),
             ];
           }
         } else {
-          return [
-            {
-              ...automaticTag,
-              class: TagClass.Automatic,
-            },
-          ];
+          return automaticTags.map((automaticTag) => ({
+            ...automaticTag,
+            class: TagClass.Denied,
+          }));
         }
       } else if (humanTags.length > 0) {
         return [

--- a/browse/src/views/GroupView.vue
+++ b/browse/src/views/GroupView.vue
@@ -15,8 +15,8 @@
           Manage the users associated with this group and view the devices
           associated with it.
         </p>
-        <b-form-checkbox v-model="filterHuman"
-          >Filter Audio Recordings of Human Speech.</b-form-checkbox
+        <b-form-checkbox v-model="filterHuman" @change="setFilterHuman">
+          Filter Audio Recordings of Human Speech.</b-form-checkbox
         >
       </div>
       <div v-else-if="group">
@@ -37,11 +37,11 @@
       <tab-list-item
         lazy
         title="Manual uploads"
-        v-if="isGroupAdmin && hasAudioOrUnknownDevices"
+        :show="isGroupAdmin && hasAudioOrUnknownDevices"
       >
         <ManualRecordingUploads :devices="devices" />
       </tab-list-item>
-      <tab-list-item lazy v-if="isGroupAdmin">
+      <tab-list-item lazy :show="isGroupAdmin">
         <template #title>
           <TabTemplate
             title="Users"
@@ -58,7 +58,7 @@
           @user-removed="(userId) => removedUser(userId)"
         />
       </tab-list-item>
-      <tab-list-item lazy v-if="visitsCount > 0">
+      <tab-list-item lazy :show="visitsCount > 0">
         <template #title>
           <TabTemplate
             title="Visits"
@@ -118,11 +118,14 @@
         />
       </tab-list-item>
 
-      <tab-list-item lazy title="Analysis" v-if="hasAudioOrUnknownDevices">
+      <tab-list-item lazy>
         <template #title>
-          <TabTemplate title="Analysis" />
+          <TabTemplate title="Stats" />
         </template>
-        <AnalysisTab :group-name="groupName" :group-id="groupId" />
+        <MonitoringAnalysisView
+          :group-id="groupId"
+          :available-types="availableMediaTypes"
+        />
       </tab-list-item>
 
       <!--      <b-tab lazy v-if="!limitedView">-->
@@ -151,10 +154,9 @@ import UsersTab from "@/components/Groups/UsersTab.vue";
 import DevicesTab from "@/components/Groups/DevicesTab.vue";
 import TabTemplate from "@/components/TabTemplate.vue";
 import RecordingsTab from "@/components/RecordingsTab.vue";
-import AnalysisTab from "@/components/Groups/AnalysisTab.vue";
 import { ApiGroupResponse, ApiGroupUserResponse } from "@typedefs/api/group";
 import { GroupId } from "@typedefs/api/common";
-import { DeviceType } from "@typedefs/api/consts";
+import { DeviceType, RecordingType } from "@typedefs/api/consts";
 import MonitoringTab from "@/components/MonitoringTab.vue";
 import GroupLink from "@/components/GroupLink.vue";
 import TabListItem from "@/components/TabListItem.vue";
@@ -162,13 +164,14 @@ import TabList from "@/components/TabList.vue";
 import ManualRecordingUploads from "@/components/ManualRecordingUploads.vue";
 import { ApiDeviceResponse } from "@typedefs/api/device";
 import Help from "@/components/Help.vue";
-
+import MonitoringAnalysisView from "./MonitoringAnalysisView.vue";
+import { defineComponent } from "@vue/composition-api";
 interface GroupViewData {
   group: ApiGroupResponse | null;
   groupId: GroupId | null;
 }
 
-export default {
+export default defineComponent({
   name: "GroupView",
   components: {
     TabListItem,
@@ -181,8 +184,8 @@ export default {
     MonitoringTab,
     TabList,
     ManualRecordingUploads,
-    AnalysisTab,
     Help,
+    MonitoringAnalysisView,
   },
   data(): Record<string, any> & GroupViewData {
     return {
@@ -204,7 +207,8 @@ export default {
       devices: [],
       stations: [],
       visits: [],
-      filterHuman: false,
+      filterHuman: null,
+      currentTabIndex: 0,
     };
   },
   computed: {
@@ -227,24 +231,15 @@ export default {
       return hasAudio || hasUnknown;
     },
     tabNames() {
-      const permissions = ["devices", "stations", "recordings", "analysis"];
-
-      if (this.isGroupAdmin) {
-        permissions.unshift("users");
-        if (this.hasAudioOrUnknownDevices) {
-          permissions.unshift("manual-uploads");
-        }
-      }
-
-      if (
-        this.devices.some(
-          (device: ApiDeviceResponse) => device.type === DeviceType.Thermal
-        )
-      ) {
-        permissions.splice(1, 0, "visits");
-      }
-
-      return permissions;
+      return [
+        "users",
+        "manual-uploads",
+        "visits",
+        "devices",
+        "stations",
+        "recordings",
+        "stats",
+      ];
     },
     nonRetiredStationsCount(): number {
       return (
@@ -256,31 +251,25 @@ export default {
     currentTabName() {
       return this.$route.params.tabName;
     },
-    currentTabIndex: {
-      get() {
-        return Math.max(0, this.tabNames.indexOf(this.currentTabName));
-      },
-      set(tabIndex) {
-        const nextTabName = this.tabNames[tabIndex];
-        if (nextTabName !== this.currentTabName) {
-          this.$router.push({
-            name: "group",
-            params: {
-              groupName: this.groupName,
-              tabName: nextTabName,
-            },
-          });
-        }
-      },
-    },
     anyDevicesAreUnhealthy() {
       return this.devices.some(
         (device) =>
           device.type === DeviceType.Thermal && device.isHealthy === false
       );
     },
+    availableMediaTypes(): Set<RecordingType> {
+      const types = new Set<RecordingType>();
+      // check if devices have thermal or audio recordings
+      if (this.devices.some((device) => device.type === DeviceType.Thermal)) {
+        types.add(RecordingType.ThermalRaw);
+      }
+      if (this.devices.some((device) => device.type === DeviceType.Audio)) {
+        types.add(RecordingType.Audio);
+      }
+      return types;
+    },
   },
-  async created() {
+  async mounted() {
     const groupRequest = await api.groups.getGroup(this.groupName);
     if (groupRequest.success) {
       const {
@@ -310,7 +299,25 @@ export default {
     }
   },
   watch: {
-    async filterHuman(newValue) {
+    currentTabIndex() {
+      const nextTabName = this.tabNames[this.currentTabIndex];
+      if (nextTabName !== this.currentTabName) {
+        this.$router.replace({
+          name: "group",
+          params: {
+            groupName: this.groupName,
+            tabName: nextTabName,
+          },
+        });
+      }
+    },
+  },
+  methods: {
+    async setFilterHuman(newValue) {
+      console.log(newValue);
+      if (newValue === null) {
+        return;
+      }
       const res = await api.groups.updateGroupSettings(this.groupName, {
         ...this.group.settings,
         filterHuman: newValue,
@@ -321,8 +328,6 @@ export default {
         this.filterHuman = this.group.settings?.filterHuman ?? true;
       }
     },
-  },
-  methods: {
     recordingQuery() {
       return {
         tagMode: "any",
@@ -427,30 +432,40 @@ export default {
     },
     async fetchStations() {
       this.stationsLoading = true;
-      {
-        const stationsResponse = await api.groups.getStationsForGroup(
-          this.groupName
+
+      const stationsResponse = await api.groups.getStationsForGroup(
+        this.groupName
+      );
+      if (stationsResponse.success) {
+        const stationIds = stationsResponse.result.stations.map(
+          (station) => station.id
         );
-        if (stationsResponse.success) {
-          this.stations = await Promise.all(
-            stationsResponse.result.stations.map(async (val) => {
-              const res = await api.station.getStationRecordingsCount(val.id);
-              return {
-                ...val,
-                recordingsCount: res.success ? res.result.count : null,
-              };
-            })
-          );
-          // get recording count for each station
+
+        const recordingsCountsResponse =
+          await api.station.getStationsRecordingsCount(stationIds);
+        const countsById = {};
+        if (recordingsCountsResponse.success) {
+          recordingsCountsResponse.result.counts.forEach((item) => {
+            countsById[item.stationId] = item.count;
+          });
         }
+
+        this.stations = stationsResponse.result.stations.map((station) => ({
+          ...station,
+          recordingsCount:
+            countsById[station.id] !== undefined
+              ? countsById[station.id]
+              : null,
+        }));
       }
+
       this.stationsLoading = false;
     },
     removedUser(userId: number) {
       this.users = this.users.filter((user) => user.id !== userId);
     },
   },
-};
+});
 </script>
 
 <style lang="scss">

--- a/browse/src/views/GroupView.vue
+++ b/browse/src/views/GroupView.vue
@@ -314,7 +314,6 @@ export default defineComponent({
   },
   methods: {
     async setFilterHuman(newValue) {
-      console.log(newValue);
       if (newValue === null) {
         return;
       }

--- a/browse/src/views/MonitoringAnalysisView.vue
+++ b/browse/src/views/MonitoringAnalysisView.vue
@@ -306,10 +306,6 @@ export default defineComponent({
 
     // User ID currently has id_ attached to it due to sorting
     const fetchTrackTagData = async () => {
-      console.log({
-        at: props.availableTypes,
-        route: route.value.query.type,
-      });
       if (props.availableTypes.size === 0) {
         return;
       } else if (!route.value.query.type) {
@@ -423,7 +419,6 @@ export default defineComponent({
             currRoute.query[query] === prevRoute.query[query];
           const queries = ["tag", "group", "station", "device", "user"];
           const isRouteSame = queries.every(isRouteQuerySame);
-          console.log(isRouteSame, currRoute.query, prevRoute.query);
           if (type !== prevType.value || !isRouteSame) {
             prevType.value = type;
             await setTrackTags();

--- a/browse/src/views/MonitoringAnalysisView.vue
+++ b/browse/src/views/MonitoringAnalysisView.vue
@@ -231,6 +231,8 @@ export default defineComponent({
 
     // Track Tags
     const trackTags = ref<(TrackTagRow & { count: number })[]>([]);
+    const audioTrackTags = ref<(TrackTagRow & { count: number })[]>([]);
+    const thermalTrackTags = ref<(TrackTagRow & { count: number })[]>([]);
     const filterTrackTags = ref<(TrackTagRow & { count: number })[]>([]);
     const isLoading = ref(false);
 
@@ -315,6 +317,16 @@ export default defineComponent({
         route.value.query.type === "audio"
           ? RecordingType.Audio
           : RecordingType.ThermalRaw;
+      if (type === RecordingType.Audio && audioTrackTags.value.length > 0) {
+        trackTags.value = audioTrackTags.value;
+        return;
+      } else if (
+        type === RecordingType.ThermalRaw &&
+        thermalTrackTags.value.length > 0
+      ) {
+        trackTags.value = thermalTrackTags.value;
+        return;
+      }
       isLoading.value = true;
       const response = await RecordingApi.queryTrackTagsCount({
         type,
@@ -336,6 +348,11 @@ export default defineComponent({
           device: { id: row.deviceId, name: row.deviceName },
           count: parseInt(row.trackTagCount),
         }));
+        if (type === RecordingType.Audio) {
+          audioTrackTags.value = trackTags.value;
+        } else {
+          thermalTrackTags.value = trackTags.value;
+        }
       }
     };
 

--- a/browse/src/views/StationView.vue
+++ b/browse/src/views/StationView.vue
@@ -58,7 +58,7 @@
     </div>
     <div v-else-if="station" class="tabs-container">
       <tab-list v-model="currentTabIndex">
-        <tab-list-item v-if="visitsCount > 0" lazy>
+        <tab-list-item :show="visitsCount > 0" lazy>
           <template #title>
             <TabTemplate
               title="Visits"
@@ -222,7 +222,9 @@ export default {
     },
     currentTabIndex: {
       get() {
-        return Math.max(0, this.tabNames.indexOf(this.currentTabName));
+        const value = Math.max(0, this.tabNames.indexOf(this.currentTabName));
+        console.log(value);
+        return value;
       },
       set(tabIndex) {
         const nextTabName = this.tabNames[tabIndex];
@@ -330,6 +332,7 @@ export default {
       }
 
       this.visitsCountLoading = false;
+      this.currentTabIndex = this.visitsCount > 0 ? 0 : 1;
     },
     async fetchAlertsCount() {
       this.alertsCountLoading = true;

--- a/browse/src/views/StationView.vue
+++ b/browse/src/views/StationView.vue
@@ -222,9 +222,7 @@ export default {
     },
     currentTabIndex: {
       get() {
-        const value = Math.max(0, this.tabNames.indexOf(this.currentTabName));
-        console.log(value);
-        return value;
+        return Math.max(0, this.tabNames.indexOf(this.currentTabName));
       },
       set(tabIndex) {
         const nextTabName = this.tabNames[tabIndex];


### PR DESCRIPTION
## Api Changes
- **get** /api/v1/recordings/track-tags/count
- **post** /api/v1/stations/recordings-count

## Features
- Add track tag statistics to users at group level ("Stats" tab in group), and across all in stats at the top (/monitoring-analysis)
- Add a composite index on deletedAt and duration, and archivedAt on track tag since it's always used. Duration check does remove corrupted recordings, but I've changed to a is not null check instead.

## Fixes
- Remove access for emails on super admin which have "read" only, includes removing the ability to view as different user.
- Changes to tab list to hide using a custom ":show" instead of using v-if, which was causing routing issues.
- Display all "master" track tags in audio track list, previously only showed first
