### PR TITLE
Fix inactive device reregister

### DIFF
--- a/api/api/auth.ts
+++ b/api/api/auth.ts
@@ -58,6 +58,7 @@ export function createEntityJWT<T>(
 export interface DecodedJWTToken {
   access?: Record<string, any>;
   _type: string;
+  activated?: boolean;
   id: number;
 }
 

--- a/api/models/Device.ts
+++ b/api/models/Device.ts
@@ -26,6 +26,7 @@ import type { User } from "./User.js";
 import type { Group } from "./Group.js";
 import type { Event } from "./Event.js";
 import logger from "../logging.js";
+import log from "@log";
 import { DeviceType } from "@typedefs/api/consts.js";
 import type {
   DeviceId,
@@ -667,7 +668,7 @@ order by hour;
               transaction: t,
             });
             if (conflictingDevice !== null) {
-              logger.warning("Got conflicting device %s", conflictingDevice);
+              logger.warn("Got conflicting device %s", conflictingDevice);
               throw new Error();
             }
             await this.update({ active: false }, { transaction: t });
@@ -725,6 +726,7 @@ order by hour;
         }
       );
     } catch (e) {
+      logger.error("Failed to re-register device %s: %s", this.deviceName, e);
       return false;
     }
     return newDevice;


### PR DESCRIPTION
- Cleanup for the previous PR #91 to remove repeated code
- Fix for device edge case where an inactive device with the same name conflicts during reassignment. When you use the "reregister" endpoint the previous device is deactivated, and new one is created, then when you try to reassign it back to the group the names conflict. This simply appends an "_old" to the inactive device