### PR TITLE
Retry failed recordings

### DIFF
--- a/api/api/V1/Reprocess.ts
+++ b/api/api/V1/Reprocess.ts
@@ -39,7 +39,7 @@ export default (app: Application, baseUrl: string) => {
   const apiUrl = `${baseUrl}/reprocess`;
 
   /**
-   * @api {get} /api/v1/reprocess/retryFailed/:id Retry processing a single recording which is in a failed state
+   * @api {get} /api/v1/reprocess/retry-failed/:id Retry processing a single recording which is in a failed state
    * @apiName Reprocess
    * @apiGroup Recordings
    * @apiParam {Integer} id of recording to retry

--- a/api/api/V1/Reprocess.ts
+++ b/api/api/V1/Reprocess.ts
@@ -51,7 +51,7 @@ export default (app: Application, baseUrl: string) => {
    * @apiUse V1ResponseError
    */
   app.get(
-    `${apiUrl}/retryFailed/:id`,
+    `${apiUrl}/retry-failed/:id`,
     extractJwtAuthorizedUser,
     validateFields([idOf(param("id"))]),
     fetchAuthorizedRequiredRecordingById(param("id")),

--- a/api/classifications/classifications.js
+++ b/api/classifications/classifications.js
@@ -1,37 +1,33 @@
 import Classifications from "@/classifications/classification.json" assert { type: "json" };
 const flattenNodes = (acc, node, parentPath) => {
-  for (const child of node.children || []) {
-    acc[child.label] = {
-      label: child.label,
-      display: child.display || child.label,
-      path: `${parentPath}.${child.label}`,
-    };
-    flattenNodes(acc, child, acc[child.label].path);
-  }
-  return acc;
+    for (const child of node.children || []) {
+        acc[child.label] = {
+            label: child.label,
+            display: child.display || child.label,
+            path: `${parentPath}.${child.label}`,
+        };
+        flattenNodes(acc, child, acc[child.label].path);
+    }
+    return acc;
 };
 export const flatClassifications = (() => {
-  const nodes = flattenNodes({}, Classifications, "all");
-  if (nodes.unknown) {
-    nodes["unidentified"] = nodes["unknown"];
-  }
-  return nodes;
+    const nodes = flattenNodes({}, Classifications, "all");
+    if (nodes.unknown) {
+        nodes["unidentified"] = nodes["unknown"];
+    }
+    return nodes;
 })();
-export const displayLabelForClassificationLabel = (
-  label,
-  aiTag = false,
-  isAudioContext = false
-) => {
-  label = label.toLowerCase();
-  if (label === "unclassified") {
-    return "AI Queued";
-  }
-  if (label === "unidentified" && aiTag) {
-    return "Unidentified";
-  }
-  const classifications = flatClassifications;
-  if ((label === "human" || label === "person") && !isAudioContext) {
-    return "human";
-  }
-  return (classifications[label] && classifications[label].display) || label;
+export const displayLabelForClassificationLabel = (label, aiTag = false, isAudioContext = false) => {
+    label = label.toLowerCase();
+    if (label === "unclassified") {
+        return "AI Queued";
+    }
+    if (label === "unidentified" && aiTag) {
+        return "Unidentified";
+    }
+    const classifications = flatClassifications;
+    if ((label === "human" || label === "person") && !isAudioContext) {
+        return "human";
+    }
+    return (classifications[label] && classifications[label].display) || label;
 };

--- a/api/models/Recording.ts
+++ b/api/models/Recording.ts
@@ -209,7 +209,7 @@ export interface Recording extends Sequelize.Model, ModelCommon<Recording> {
   getGroup: () => Promise<Group>;
 
   getActiveTracksTagsAndTagger: () => Promise<any>;
-  retryProcessing: () => Promise<Recording>;
+  retryFailed: () => Promise<Recording>;
   reprocess: () => Promise<Recording>;
   filterData: (options: any) => void;
   // NOTE: Implicitly created by sequelize associations (along with other
@@ -788,13 +788,14 @@ from (
   }
 
   // retry processing this recording
-  Recording.prototype.retryProcessing = async function () {
+  Recording.prototype.retryFailed = async function () {
     if (!this.processingState.endsWith(".failed")) {
-      return null;
+      return false;
     }
     await this.update({
       processingState: this.processingState.replace(".failed", ""),
     });
+    return true;
   };
 
   // reprocess a recording and set all active tracks to archived

--- a/api/models/Recording.ts
+++ b/api/models/Recording.ts
@@ -209,7 +209,7 @@ export interface Recording extends Sequelize.Model, ModelCommon<Recording> {
   getGroup: () => Promise<Group>;
 
   getActiveTracksTagsAndTagger: () => Promise<any>;
-
+  retryProcessing: () => Promise<Recording>;
   reprocess: () => Promise<Recording>;
   filterData: (options: any) => void;
   // NOTE: Implicitly created by sequelize associations (along with other
@@ -786,6 +786,16 @@ from (
       lng: reducePrecision(latLng.lng),
     };
   }
+
+  // retry processing this recording
+  Recording.prototype.retryProcessing = async function () {
+    if (!this.processingState.endsWith(".failed")) {
+      return null;
+    }
+    await this.update({
+      processingState: this.processingState.replace(".failed", ""),
+    });
+  };
 
   // reprocess a recording and set all active tracks to archived
   Recording.prototype.reprocess = async function () {

--- a/api/scripts/influx-metrics.ts
+++ b/api/scripts/influx-metrics.ts
@@ -62,7 +62,7 @@ async function measureProcessingWaitTime(influx, pgClient) {
   const res = await pgQuery(
     pgClient,
     `select "createdAt" from "Recordings"
-    where "processingState" in ('analyse', 'tracking') and "deletedAt" is null
+    where "processingState" in ('analyse', 'tracking') and "deletedAt" is null and "processingFailedCount" = 0
     order by "createdAt" asc limit 1`
   );
 

--- a/browse/src/api/Recording.api.ts
+++ b/browse/src/api/Recording.api.ts
@@ -547,7 +547,7 @@ function deleteRecordingTag(
 }
 
 function retryFailed(id: RecordingId): Promise<FetchResult<void>> {
-  return CacophonyApi.get(`/api/v1/reprocess/retryFailed/${id}`);
+  return CacophonyApi.get(`/api/v1/reprocess/retry-failed/${id}`);
 }
 
 function thumbnail(id: RecordingId): string {

--- a/browse/src/api/Recording.api.ts
+++ b/browse/src/api/Recording.api.ts
@@ -546,8 +546,8 @@ function deleteRecordingTag(
   return CacophonyApi.delete(`${apiPath}/${id}/tags/${tagId}`);
 }
 
-function retryProcessing(id: RecordingId): Promise<FetchResult<void>> {
-  return CacophonyApi.get(`/api/v1/reprocess/retry/${id}`);
+function retryFailed(id: RecordingId): Promise<FetchResult<void>> {
+  return CacophonyApi.get(`/api/v1/reprocess/retryFailed/${id}`);
 }
 
 function thumbnail(id: RecordingId): string {
@@ -641,7 +641,7 @@ export default {
   deleteTrack,
   undeleteTrack,
   updateTrack,
-  retryProcessing,
+  retryFailed,
   addTrackTag,
   deleteTrackTag,
   replaceTrackTag,

--- a/browse/src/api/Recording.api.ts
+++ b/browse/src/api/Recording.api.ts
@@ -546,8 +546,8 @@ function deleteRecordingTag(
   return CacophonyApi.delete(`${apiPath}/${id}/tags/${tagId}`);
 }
 
-function reprocess(id: RecordingId): Promise<FetchResult<void>> {
-  return CacophonyApi.get(`/api/v1/reprocess/${id}`);
+function retryProcessing(id: RecordingId): Promise<FetchResult<void>> {
+  return CacophonyApi.get(`/api/v1/reprocess/retry/${id}`);
 }
 
 function thumbnail(id: RecordingId): string {
@@ -641,7 +641,7 @@ export default {
   deleteTrack,
   undeleteTrack,
   updateTrack,
-  reprocess,
+  retryProcessing,
   addTrackTag,
   deleteTrackTag,
   replaceTrackTag,

--- a/browse/src/components/Video/VideoRecording.vue
+++ b/browse/src/components/Video/VideoRecording.vue
@@ -329,7 +329,7 @@ export default {
   },
   methods: {
     async reprocess() {
-      const { success } = await api.recording.reprocess(this.recordingId);
+      const { success } = await api.recording.retryProcessing(this.recordingId);
       if (success) {
         this.$emit("recording-updated", {
           id: this.recordingId,

--- a/browse/src/components/Video/VideoRecording.vue
+++ b/browse/src/components/Video/VideoRecording.vue
@@ -329,7 +329,7 @@ export default {
   },
   methods: {
     async reprocess() {
-      const { success } = await api.recording.retryProcessing(this.recordingId);
+      const { success } = await api.recording.retryFailed(this.recordingId);
       if (success) {
         this.$emit("recording-updated", {
           id: this.recordingId,


### PR DESCRIPTION
Rather than using reprocess endpoint which was mean't for changing tracking algorithms and always reprocessing from scratch. Added new endpoint retry failed, for retry a recordings current failed state.
Changed browse to use this endpoint.