### PR TITLE
added tracking score

### DIFF
--- a/api/api/V1/Recording.ts
+++ b/api/api/V1/Recording.ts
@@ -191,6 +191,9 @@ export const mapTrack = (
   if (!minimal && track.data.positions && track.data.positions.length) {
     t.positions = track.data.positions.map(mapPosition);
   }
+  if (!minimal) {
+    t.tracking_score = track.data.tracking_score;
+  }
   return t;
 };
 

--- a/types/api/fileProcessing.d.ts
+++ b/types/api/fileProcessing.d.ts
@@ -72,7 +72,7 @@ interface RawTrack {
   frame_end: integer;
   positions: TrackFramePosition[];
   predictions: TrackClassification[];
-
+  tracking_score: float;
   // Fields used in api when calculating good tracks/tags
   confidence?: FloatZeroToOne;
   message?: string;
@@ -92,7 +92,7 @@ export interface MinimalTrackRequestData {
   minFreq?: integer;
   maxFreq?: integer;
   scale?: string;
-
+  tracking_score: float;
   num_frames?: integer;
   frame_start?: integer;
   frame_end?: integer;

--- a/types/api/track.d.ts
+++ b/types/api/track.d.ts
@@ -26,6 +26,7 @@ export interface ApiTrackResponse {
   filtered?: boolean;
   minFreq?: number;
   maxFreq?: number;
+  tracking_score?: number;
 }
 
 export interface ApiTrackRequest {


### PR DESCRIPTION
Added tracking_score to be served and accepted as track metadata.
This is a score calculate by classifier-pipeline tracking based on movement and blank regions