### PR TITLE
bump multiparty to 4.3.0 to fix multipart filename DoS/ReDoS

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -34,7 +34,7 @@
         "mime": "^2.4.4",
         "moment": "^2.29.1",
         "moment-timezone": "^0.5.28",
-        "multiparty": "^4.2.3",
+        "multiparty": "^4.3.0",
         "passport": "^0.6.0",
         "passport-jwt": "^4.0.0",
         "pg": "^8.11.0",
@@ -6995,10 +6995,12 @@
       }
     },
     "node_modules/multiparty": {
-      "version": "4.2.3",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-4.3.0.tgz",
+      "integrity": "sha512-LD3YDFI9KrDoOGHsPM+hNraPDQQDPLe8Un/kvJfsZCsHKriA4mphg6Ctc2Cuup/59DtHMdAPm6ICXlUmhwTiug==",
       "license": "MIT",
       "dependencies": {
-        "http-errors": "~1.8.1",
+        "http-errors": "2.0.0",
         "safe-buffer": "5.2.1",
         "uid-safe": "2.1.5"
       },
@@ -7006,18 +7008,29 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/multiparty/node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/multiparty/node_modules/http-errors": {
-      "version": "1.8.1",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
       "license": "MIT",
       "dependencies": {
-        "depd": "~1.1.2",
+        "depd": "2.0.0",
         "inherits": "2.0.4",
         "setprototypeof": "1.2.0",
-        "statuses": ">= 1.5.0 < 2",
+        "statuses": "2.0.1",
         "toidentifier": "1.0.1"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 0.8"
       }
     },
     "node_modules/multiparty/node_modules/safe-buffer": {
@@ -7040,10 +7053,23 @@
     },
     "node_modules/multiparty/node_modules/setprototypeof": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/multiparty/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/multiparty/node_modules/toidentifier": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.6"

--- a/api/package.json
+++ b/api/package.json
@@ -43,7 +43,7 @@
     "mime": "^2.4.4",
     "moment": "^2.29.1",
     "moment-timezone": "^0.5.28",
-    "multiparty": "^4.2.3",
+    "multiparty": "^4.3.0",
     "passport": "^0.6.0",
     "passport-jwt": "^4.0.0",
     "pg": "^8.11.0",


### PR DESCRIPTION
multiparty handles the multipart/form-data on the device upload path (api/V1/util.ts, uploadGenericRecording.ts), so the filename in the request is attacker-controlled. 4.2.3 has three high advisories, all in filename parsing:

- GHSA-65x3-rw7q-gx94 - ReDoS via filename
- GHSA-qxch-whhj-8956 - prototype pollution -> uncaught exception
- GHSA-xh3c-6gcq-g4rv - uncaught exception in filename* parsing

4.3.0 sorts all three. No API change - we just use new multiparty.Form() with the part event, which is the same. Lockfile change stays within the multiparty subtree, and npm audit --omit=dev comes back clean for it with nothing new.
