### PR TITLE
bump handlebars to 4.7.9 to fix template injection advisories

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -24,7 +24,7 @@
         "express-winston": "^4.1.0",
         "fast-csv": "^4.3.6",
         "fluent-ffmpeg": "^2.1.2",
-        "handlebars": "^4.7.7",
+        "handlebars": "^4.7.9",
         "influx": "^5.9.2",
         "jsdom": "^19.0.0",
         "jsonschema": "^1.4.0",
@@ -5660,11 +5660,13 @@
       "license": "MIT"
     },
     "node_modules/handlebars": {
-      "version": "4.7.7",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5",
-        "neo-async": "^2.6.0",
+        "neo-async": "^2.6.2",
         "source-map": "^0.6.1",
         "wordwrap": "^1.0.0"
       },
@@ -9894,6 +9896,19 @@
     "node_modules/uc.micro": {
       "version": "1.0.6",
       "license": "MIT"
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/uid-safe": {
       "version": "2.1.5",

--- a/api/package.json
+++ b/api/package.json
@@ -33,7 +33,7 @@
     "express-winston": "^4.1.0",
     "fast-csv": "^4.3.6",
     "fluent-ffmpeg": "^2.1.2",
-    "handlebars": "^4.7.7",
+    "handlebars": "^4.7.9",
     "influx": "^5.9.2",
     "jsdom": "^19.0.0",
     "jsonschema": "^1.4.0",


### PR DESCRIPTION
handlebars compiles our email templates (api/emails). 4.7.7 has a critical AST type-confusion JS injection (GHSA-2w6w-674q-4c4q) plus a few high/moderate prototype-access and decorator DoS ones. 4.7.9 fixes the lot.

Our templates are static and trusted so the real risk is low, but it clears the critical and keeps audit tidy. No template API change. Lockfile change stays within the handlebars subtree (handlebars, neo-async, and its optional uglify-js). npm audit --omit=dev critical count goes 2 -> 1, nothing new.
